### PR TITLE
Fix notification crashes caused by unknown notification type

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/CacheController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/CacheController.java
@@ -195,6 +195,9 @@ public class CacheController{
 				db.delete(table, null, null);
 			ContentValues values=new ContentValues(3);
 			for(Notification n:notifications){
+				if(n.type==null){
+					continue;
+				}
 				values.put("id", n.id);
 				values.put("json", MastodonAPIController.gson.toJson(n));
 				values.put("type", n.type.ordinal());


### PR DESCRIPTION
Thanks for developing this elegant app!
I encountered a crash caused by new sign up notifications so I made a quick fix for that.
If you think there's better way to fix this problem, feel free to close this PR.

```
E/AndroidRuntime: FATAL EXCEPTION: databaseThread
    Process: org.joinmastodon.android, PID: 1642
    java.lang.NullPointerException: Attempt to invoke virtual method 'int org.joinmastodon.android.model.Notification$Type.ordinal()' on a null object reference
        at org.joinmastodon.android.api.CacheController.lambda$putNotifications$9(CacheController.java:200)
        at org.joinmastodon.android.api.CacheController$$ExternalSyntheticLambda5.run(Unknown Source:6)
        at org.joinmastodon.android.api.CacheController.lambda$runOnDbThread$14(CacheController.java:268)
        at org.joinmastodon.android.api.CacheController.$r8$lambda$s8ETJe7YHvU35-CsGtQJHgulQC0(Unknown Source:0)
        at org.joinmastodon.android.api.CacheController$$ExternalSyntheticLambda12.run(Unknown Source:6)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at me.grishka.appkit.utils.WorkerThread.run(WorkerThread.java:54)
```