### PR TITLE
Minor change: add suffix to debug builds

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -21,6 +21,7 @@ android {
 			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 		}
 		debug{
+			applicationIdSuffix ".debug"
 			debuggable true
 		}
 		appcenterPrivateBeta{


### PR DESCRIPTION
Adding suffix to debug builds allows easy install of both dev and release builds side by side; and can be identified in logs.