### PR TITLE
Display full image when adding image description

### DIFF
--- a/mastodon/src/main/res/layout/fragment_image_description.xml
+++ b/mastodon/src/main/res/layout/fragment_image_description.xml
@@ -9,14 +9,21 @@
 		android:layout_height="wrap_content"
 		android:orientation="vertical">
 
-		<ImageView
-			android:id="@+id/photo"
+		<org.joinmastodon.android.ui.views.MaxWidthFrameLayout
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:scaleType="fitXY"
-			android:adjustViewBounds="true"
-			android:importantForAccessibility="no"
-			tools:src="#0f0" />
+			android:layout_gravity="center"
+			android:maxWidth="400dp">
+
+			<ImageView
+				android:id="@+id/photo"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:adjustViewBounds="true"
+				android:importantForAccessibility="no"
+				tools:src="#0f0" />
+
+		</org.joinmastodon.android.ui.views.MaxWidthFrameLayout>
 
 		<TextView
 			android:id="@+id/title"

--- a/mastodon/src/main/res/layout/fragment_image_description.xml
+++ b/mastodon/src/main/res/layout/fragment_image_description.xml
@@ -18,7 +18,7 @@
 			<ImageView
 				android:id="@+id/photo"
 				android:layout_width="match_parent"
-				android:layout_height="match_parent"
+				android:layout_height="wrap_content"
 				android:adjustViewBounds="true"
 				android:importantForAccessibility="no"
 				tools:src="#0f0"/>

--- a/mastodon/src/main/res/layout/fragment_image_description.xml
+++ b/mastodon/src/main/res/layout/fragment_image_description.xml
@@ -21,7 +21,7 @@
 				android:layout_height="match_parent"
 				android:adjustViewBounds="true"
 				android:importantForAccessibility="no"
-				tools:src="#0f0" />
+				tools:src="#0f0"/>
 
 		</org.joinmastodon.android.ui.views.MaxWidthFrameLayout>
 

--- a/mastodon/src/main/res/layout/fragment_image_description.xml
+++ b/mastodon/src/main/res/layout/fragment_image_description.xml
@@ -9,20 +9,14 @@
 		android:layout_height="wrap_content"
 		android:orientation="vertical">
 
-		<org.joinmastodon.android.ui.views.ComposeMediaLayout
-			android:layout_width="wrap_content"
+		<ImageView
+			android:id="@+id/photo"
+			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:layout_gravity="center_horizontal">
-
-			<ImageView
-				android:id="@+id/photo"
-				android:layout_width="match_parent"
-				android:layout_height="match_parent"
-				android:scaleType="centerCrop"
-				android:importantForAccessibility="no"
-				tools:src="#0f0"/>
-
-		</org.joinmastodon.android.ui.views.ComposeMediaLayout>
+			android:scaleType="fitXY"
+			android:adjustViewBounds="true"
+			android:importantForAccessibility="no"
+			tools:src="#0f0" />
 
 		<TextView
 			android:id="@+id/title"


### PR DESCRIPTION
Fixes #139 
* Don't use `ComposeMediaLayout` as it's also used when attaching images to posts – always displaying them cropped, rendering it unusable for composing image descriptions
* Use `MaxWidthFrameLayout` instead to have the image obey the 400dp max width