### PR TITLE
Add unlisted visibility on Long click

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -261,6 +261,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		emojiBtn.setOnClickListener(v->emojiKeyboard.toggleKeyboardPopup(mainEditText));
 		spoilerBtn.setOnClickListener(v->toggleSpoiler());
 		visibilityBtn.setOnClickListener(this::onVisibilityClick);
+		visibilityBtn.setOnLongClickListener(this::onVisibilityLongClick);
 		emojiKeyboard.setOnIconChangedListener(new PopupKeyboard.OnIconChangeListener(){
 			@Override
 			public void onIconChanged(int icon){
@@ -1033,16 +1034,23 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		UiUtils.enablePopupMenuIcons(getActivity(), menu);
 		m.setGroupCheckable(0, true, true);
 		m.findItem(switch(statusVisibility){
-			case PUBLIC, UNLISTED -> R.id.vis_public;
+			case PUBLIC -> R.id.vis_public;
+			case UNLISTED -> R.id.vis_unlisted;
 			case PRIVATE -> R.id.vis_followers;
 			case DIRECT -> R.id.vis_private;
 		}).setChecked(true);
+
+		if (statusVisibility != StatusPrivacy.UNLISTED) {
+			m.findItem(R.id.vis_unlisted).setVisible(false);
+		}
 		menu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener(){
 			@Override
 			public boolean onMenuItemClick(MenuItem item){
 				int id=item.getItemId();
-				if(id==R.id.vis_public){
+				if(id==R.id.vis_public) {
 					statusVisibility=StatusPrivacy.PUBLIC;
+				}else if(id==R.id.vis_unlisted) {
+					statusVisibility=StatusPrivacy.UNLISTED;
 				}else if(id==R.id.vis_followers){
 					statusVisibility=StatusPrivacy.PRIVATE;
 				}else if(id==R.id.vis_private){
@@ -1054,6 +1062,12 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			}
 		});
 		menu.show();
+	}
+
+	private boolean onVisibilityLongClick(View v) {
+		statusVisibility = StatusPrivacy.UNLISTED;
+		updateVisibilityIcon();
+		return true;
 	}
 
 	private void updateVisibilityIcon(){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -1040,16 +1040,16 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			case DIRECT -> R.id.vis_private;
 		}).setChecked(true);
 
-		if (statusVisibility != StatusPrivacy.UNLISTED) {
+		if (statusVisibility != StatusPrivacy.UNLISTED){
 			m.findItem(R.id.vis_unlisted).setVisible(false);
 		}
 		menu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener(){
 			@Override
 			public boolean onMenuItemClick(MenuItem item){
 				int id=item.getItemId();
-				if(id==R.id.vis_public) {
+				if(id==R.id.vis_public){
 					statusVisibility=StatusPrivacy.PUBLIC;
-				}else if(id==R.id.vis_unlisted) {
+				}else if(id==R.id.vis_unlisted){
 					statusVisibility=StatusPrivacy.UNLISTED;
 				}else if(id==R.id.vis_followers){
 					statusVisibility=StatusPrivacy.PRIVATE;
@@ -1064,7 +1064,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		menu.show();
 	}
 
-	private boolean onVisibilityLongClick(View v) {
+	private boolean onVisibilityLongClick(View v){
 		statusVisibility = StatusPrivacy.UNLISTED;
 		updateVisibilityIcon();
 		return true;

--- a/mastodon/src/main/res/menu/compose_visibility.xml
+++ b/mastodon/src/main/res/menu/compose_visibility.xml
@@ -3,6 +3,9 @@
 	<item android:id="@+id/vis_public"
 		android:icon="@drawable/ic_fluent_earth_24_filled"
 		android:title="@string/visibility_public"/>
+	<item android:id="@+id/vis_unlisted"
+		android:icon="@drawable/ic_fluent_people_community_24_regular"
+		android:title="Unlisted"/>
 	<item android:id="@+id/vis_followers"
 		android:icon="@drawable/ic_fluent_people_checkmark_24_regular"
 		android:title="@string/visibility_followers_only"/>

--- a/mastodon/src/main/res/menu/compose_visibility.xml
+++ b/mastodon/src/main/res/menu/compose_visibility.xml
@@ -5,7 +5,7 @@
 		android:title="@string/visibility_public"/>
 	<item android:id="@+id/vis_unlisted"
 		android:icon="@drawable/ic_fluent_people_community_24_regular"
-		android:title="Unlisted"/>
+		android:title="@string/visibility_unlisted"/>
 	<item android:id="@+id/vis_followers"
 		android:icon="@drawable/ic_fluent_people_checkmark_24_regular"
 		android:title="@string/visibility_followers_only"/>

--- a/mastodon/src/main/res/values-ko-rKR/strings.xml
+++ b/mastodon/src/main/res/values-ko-rKR/strings.xml
@@ -165,6 +165,7 @@
 	<string name="save">저장</string>
 	<string name="add_alt_text">대체 텍스트 추가</string>
 	<string name="visibility_public">공개</string>
+	<string name="visibility_unlisted">비공개</string>
 	<string name="visibility_followers_only">팔로워 전용</string>
 	<string name="visibility_private">멘션한 사람만</string>
 	<string name="search_all">모두</string>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -218,6 +218,7 @@
 	<string name="alt_text_subtitle">Alt text describes your photos for people with low or no vision. Try to only include enough detail to understand the context.</string>
 	<string name="alt_text_hint">e.g. A dog looking around suspiciously with narrowed eyes at the camera.</string>
 	<string name="visibility_public">Public</string>
+	<string name="visibility_public">Unlisted</string>
 	<string name="visibility_followers_only">Followers only</string>
 	<string name="visibility_private">Only people I mention</string>
 	<string name="search_all">All</string>


### PR DESCRIPTION
A lot of people want to use "unlisted" visibility. But @Gargron said that

>This option has been omitted on purpose since it overlaps with public in almost all ways. We keep the dropdown simple, with all other options being very intuitive to understand.

So this PR keeps that dropdown menu simple, but few changes.

- Show unlisted visibility only when unlisted is selected (hidden by default) (eg, replying to unlisted post)
- Change visibility setting to "unlisted" when long pressed privacy menu (Like hidden feature)

https://user-images.githubusercontent.com/5047683/170216453-3678b34b-2e04-42a3-8b62-a3dad7c644f4.mp4


