### PR TITLE
Issue [263]: Add support for "supported links"

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -26,6 +26,13 @@
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="https" />
+				<data android:host="mastodon.social" />
+			</intent-filter>
 		</activity>
 		<activity android:name=".OAuthActivity" android:exported="true" android:configChanges="orientation|screenSize" android:launchMode="singleTask">
 			<intent-filter>
@@ -61,7 +68,6 @@
 				<category android:name="me.grishka.fcmtest"/>
 			</intent-filter>
 		</receiver>
-
 	</application>
 
 </manifest>


### PR DESCRIPTION
Issue - https://github.com/mastodon/mastodon-android/issues/263

This is my first small PR here to just help user to navigate to the app rather than going to the browser.
The next steps will be based on URLs, helping the user to navigate to the correct screen.

Below is the screenshot from the Pixel 5 API 33
<img src="https://user-images.githubusercontent.com/25057618/198877491-e0a47de9-004b-4e8b-8609-933201971234.png" width=220 height="450" />
