### PR TITLE
Fix receiving images from keyboards

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/views/ComposeEditText.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/views/ComposeEditText.java
@@ -54,12 +54,13 @@ public class ComposeEditText extends EditText{
 	// Support receiving images from keyboards
 	@Override
 	public InputConnection onCreateInputConnection(EditorInfo outAttrs){
+		final var ic = super.onCreateInputConnection(outAttrs);
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N_MR1){
 			outAttrs.contentMimeTypes=selectionListener.onGetAllowedMediaMimeTypes();
-			inputConnectionWrapper.setTarget(super.onCreateInputConnection(outAttrs));
+			inputConnectionWrapper.setTarget(ic);
 			return inputConnectionWrapper;
 		}
-		return super.onCreateInputConnection(outAttrs);
+		return ic;
 	}
 
 	// Support pasting images


### PR DESCRIPTION
Fixes #90 

The call to `super.onCreateInputConnection` was overwriting the mimes in the `outAttrs`, so we can call that first and then modify the mimes.

This fixes the ability to insert GIFs with the default GBoard GIF menu for me.