### PR TITLE
Load post privacy preference

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/GetPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/GetPreferences.java
@@ -1,0 +1,10 @@
+package org.joinmastodon.android.api.requests.accounts;
+
+import org.joinmastodon.android.api.MastodonAPIRequest;
+import org.joinmastodon.android.model.Preferences;
+
+public class GetPreferences extends MastodonAPIRequest<Preferences> {
+    public GetPreferences(){
+        super(HttpMethod.GET, "/preferences", Preferences.class);
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/ExpandMedia.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/ExpandMedia.java
@@ -1,0 +1,12 @@
+package org.joinmastodon.android.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum ExpandMedia {
+    @SerializedName("default")
+    DEFAULT,
+    @SerializedName("show_all")
+    SHOW_ALL,
+    @SerializedName("hide_all")
+    HIDE_ALL;
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Preferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Preferences.java
@@ -1,0 +1,38 @@
+package org.joinmastodon.android.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Preferred common behaviors to be shared across clients.
+ */
+public class Preferences extends BaseModel {
+    /**
+     * Default visibility for new posts
+     */
+    @SerializedName("posting:default:visibility")
+    public StatusPrivacy postingDefaultVisibility;
+
+    /**
+     * Default sensitivity flag for new posts
+     */
+    @SerializedName("posting:default:sensitive")
+    public boolean postingDefaultSensitive;
+
+    /**
+     * Default language for new posts
+     */
+    @SerializedName("posting:default:language")
+    public String postingDefaultLanguage;
+
+    /**
+     * Whether media attachments should be automatically displayed or blurred/hidden.
+     */
+    @SerializedName("reading:expand:media")
+    public ExpandMedia readingExpandMedia;
+
+    /**
+     * Whether CWs should be expanded by default.
+     */
+    @SerializedName("reading:expand:spoilers")
+    public boolean readingExpandSpoilers;
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/StatusPrivacy.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/StatusPrivacy.java
@@ -4,11 +4,25 @@ import com.google.gson.annotations.SerializedName;
 
 public enum StatusPrivacy{
 	@SerializedName("public")
-	PUBLIC,
+	PUBLIC(0),
 	@SerializedName("unlisted")
-	UNLISTED,
+	UNLISTED(1),
 	@SerializedName("private")
-	PRIVATE,
+	PRIVATE(2),
 	@SerializedName("direct")
-	DIRECT;
+	DIRECT(3);
+
+	private int privacy;
+
+	StatusPrivacy(int privacy) {
+		this.privacy = privacy;
+	}
+
+	public boolean isLessVisibleThan(StatusPrivacy other) {
+		return privacy > other.getPrivacy();
+	}
+
+	public int getPrivacy() {
+		return privacy;
+	}
 }


### PR DESCRIPTION
Fixes #266 

This queries the user's post visibility preference when opening the composer, and sets it on the composer.

In the case of composing a reply, the user's preference is only respected if it is "more private" than the privacy of the post being replied to, as this appears to be the behaviour in the web interface (and is what I'd expect)