### PR TITLE
Check whether title status item is null to fix null pointer exception

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.SimpleCallback;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -22,10 +22,12 @@ import org.parceler.Parcels;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.SimpleCallback;
@@ -76,9 +78,11 @@ public class NotificationsListFragment extends BaseStatusListFragment<Notificati
 			if(titleItem!=null)
 				items.add(0, titleItem);
 			return items;
-		}else{
+		}else if(extraText!=null){
 			AccountCardStatusDisplayItem card=new AccountCardStatusDisplayItem(n.id, this, n.account);
 			return Arrays.asList(titleItem, card);
+		}else{
+			return Collections.emptyList();
 		}
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -77,7 +77,7 @@ public class NotificationsListFragment extends BaseStatusListFragment<Notificati
 			if(titleItem!=null)
 				items.add(0, titleItem);
 			return items;
-		}else if(extraText!=null){
+		}else if(titleItem!=null){
 			AccountCardStatusDisplayItem card=new AccountCardStatusDisplayItem(n.id, this, n.account);
 			return Arrays.asList(titleItem, card);
 		}else{


### PR DESCRIPTION
Fixes #227, caused by an edge case where a notification type was "status", but "status" was null. This caused the `buildDisplayItems` method (in `NotificationsListFragment`) to falsely assume the `titleItem` to not be null, resulting in a null pointer exception and the app crashing.