### PR TITLE
Add Android 13 per-app language preferences

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -12,6 +12,10 @@ android {
 		versionCode 43
 		versionName "1.1.4"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+		resConfigs "en", "ar-rSA", "bs-rBA", "ca-rES", "cs-rCZ", "de-rDE", "el-rGR", "es-rES",
+				"eu-rES", "fi-rFI", "fr-rFR", "gl-rES", "hr-rHR", "hy-rAM", "it-rIT", "iw-rIL",
+				"ja-rJP", "kab", "ko-rKR", "oc-rFR", "pl-rPL", "pt-rBR", "pt-rPT", "ru-rRU",
+				"sv-rSE", "th-rTH", "tr-rTR", "uk-rUA", "vi-rVN", "zh-rCN", "zh-rTW"
 	}
 
 	buildTypes {

--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
 		android:allowBackup="true"
 		android:label="@string/app_name"
 		android:supportsRtl="true"
+		android:localeConfig="@xml/locales_config"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:theme="@style/Theme.Mastodon.AutoLightDark"

--- a/mastodon/src/main/res/xml/locales_config.xml
+++ b/mastodon/src/main/res/xml/locales_config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="ar" />
+    <locale android:name="bs" />
+    <locale android:name="ca" />
+    <locale android:name="cs" />
+    <locale android:name="de" />
+    <locale android:name="el" />
+    <locale android:name="es" />
+    <locale android:name="eu" />
+    <locale android:name="fi" />
+    <locale android:name="fr" />
+    <locale android:name="gl" />
+    <locale android:name="hr" />
+    <locale android:name="hy" />
+    <locale android:name="it" />
+    <locale android:name="iw" />
+    <locale android:name="ja" />
+    <locale android:name="kab" />
+    <locale android:name="ko" />
+    <locale android:name="oc" />
+    <locale android:name="pl" />
+    <locale android:name="pt-BR" />
+    <locale android:name="pt-PT" />
+    <locale android:name="ru" />
+    <locale android:name="sv" />
+    <locale android:name="th" />
+    <locale android:name="tr" />
+    <locale android:name="uk" />
+    <locale android:name="vi" />
+    <locale android:name="zh-Hans" />
+    <locale android:name="zh-Hant" />
+</locale-config>


### PR DESCRIPTION
Add Android 13 per-app language preferences to allow multilingual users set their system language to one language but select another languages for the app.