### PR TITLE
Add timeline filters for replies and boosts

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -7,6 +7,8 @@ public class GlobalUserPreferences{
 	public static boolean playGifs;
 	public static boolean useCustomTabs;
 	public static boolean trueBlackTheme;
+	public static boolean showReplies;
+	public static boolean showBoosts;
 	public static ThemePreference theme;
 
 	private static SharedPreferences getPrefs(){
@@ -18,6 +20,8 @@ public class GlobalUserPreferences{
 		playGifs=prefs.getBoolean("playGifs", true);
 		useCustomTabs=prefs.getBoolean("useCustomTabs", true);
 		trueBlackTheme=prefs.getBoolean("trueBlackTheme", false);
+		showReplies=prefs.getBoolean("showReplies", true);
+		showBoosts=prefs.getBoolean("showBoosts", true);
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
 	}
 
@@ -25,6 +29,8 @@ public class GlobalUserPreferences{
 		getPrefs().edit()
 				.putBoolean("playGifs", playGifs)
 				.putBoolean("useCustomTabs", useCustomTabs)
+				.putBoolean("showReplies", showReplies)
+				.putBoolean("showBoosts", showBoosts)
 				.putBoolean("trueBlackTheme", trueBlackTheme)
 				.putInt("theme", theme.ordinal())
 				.apply();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
@@ -24,6 +24,7 @@ import android.widget.Toolbar;
 import com.squareup.otto.Subscribe;
 
 import org.joinmastodon.android.E;
+import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.timelines.GetHomeTimeline;
 import org.joinmastodon.android.api.session.AccountSessionManager;
@@ -82,7 +83,12 @@ public class HomeTimelineFragment extends StatusListFragment{
 					public void onSuccess(CacheablePaginatedResponse<List<Status>> result){
 						if(getActivity()==null)
 							return;
-						onDataLoaded(result.items, !result.items.isEmpty());
+						List<Status> filteredItems = result.items.stream().filter(i ->
+								(GlobalUserPreferences.showReplies || i.inReplyToId == null) &&
+								(GlobalUserPreferences.showBoosts || i.reblog == null)
+						).collect(Collectors.toList());
+
+						onDataLoaded(filteredItems, !result.items.isEmpty());
 						maxID=result.maxID;
 						if(result.isFromCache())
 							loadNewPosts();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -103,7 +103,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 			GlobalUserPreferences.save();
 		}));
 
-		items.add(new HeaderItem(R.string.settings_timeline));
+		items.add(new HeaderItem(R.string.home_timeline));
 		items.add(new SwitchItem(R.string.settings_show_replies, R.drawable.ic_fluent_chat_multiple_24_regular, GlobalUserPreferences.showReplies, i->{
 			GlobalUserPreferences.showReplies=i.checked;
 			GlobalUserPreferences.save();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -103,6 +103,16 @@ public class SettingsFragment extends MastodonToolbarFragment{
 			GlobalUserPreferences.save();
 		}));
 
+		items.add(new HeaderItem(R.string.settings_timeline));
+		items.add(new SwitchItem(R.string.settings_show_replies, R.drawable.ic_fluent_chat_multiple_24_regular, GlobalUserPreferences.showReplies, i->{
+			GlobalUserPreferences.showReplies=i.checked;
+			GlobalUserPreferences.save();
+		}));
+		items.add(new SwitchItem(R.string.settings_show_boosts, R.drawable.ic_fluent_arrow_repeat_all_24_regular, GlobalUserPreferences.showBoosts, i->{
+			GlobalUserPreferences.showBoosts=i.checked;
+			GlobalUserPreferences.save();
+		}));
+
 		items.add(new HeaderItem(R.string.settings_notifications));
 		items.add(notificationPolicyItem=new NotificationPolicyItem());
 		PushSubscription pushSubscription=getPushSubscription();

--- a/mastodon/src/main/res/values-de-rDE/strings.xml
+++ b/mastodon/src/main/res/values-de-rDE/strings.xml
@@ -236,6 +236,9 @@
 	<string name="theme_dark">Dunkel</string>
 	<string name="theme_true_black">AMOLED-Modus</string>
 	<string name="settings_behavior">App-Verhalten</string>
+	<string name="settings_timeline">Timeline</string>
+	<string name="settings_show_replies">Antworten anzeigen</string>
+	<string name="settings_show_boosts">Geteilte Beiträge anzeigen</string>
 	<string name="settings_gif">Spiele animierte GIFs, Avatare und Emojis ab</string>
 	<string name="settings_custom_tabs">In-App-Browser verwenden</string>
 	<string name="settings_notifications">Benachrichtigungen</string>

--- a/mastodon/src/main/res/values-de-rDE/strings.xml
+++ b/mastodon/src/main/res/values-de-rDE/strings.xml
@@ -236,7 +236,6 @@
 	<string name="theme_dark">Dunkel</string>
 	<string name="theme_true_black">AMOLED-Modus</string>
 	<string name="settings_behavior">App-Verhalten</string>
-	<string name="settings_timeline">Timeline</string>
 	<string name="settings_show_replies">Antworten anzeigen</string>
 	<string name="settings_show_boosts">Geteilte Beiträge anzeigen</string>
 	<string name="settings_gif">Spiele animierte GIFs, Avatare und Emojis ab</string>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -242,6 +242,9 @@
 	<string name="theme_dark">Dark</string>
 	<string name="theme_true_black">True black mode</string>
 	<string name="settings_behavior">Behavior</string>
+	<string name="settings_timeline">Timeline</string>
+	<string name="settings_show_replies">Show replies</string>
+	<string name="settings_show_boosts">Show boosts</string>
 	<string name="settings_gif">Play animated avatars and emoji</string>
 	<string name="settings_custom_tabs">Use in-app browser</string>
 	<string name="settings_notifications">Notifications</string>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -242,7 +242,6 @@
 	<string name="theme_dark">Dark</string>
 	<string name="theme_true_black">True black mode</string>
 	<string name="settings_behavior">Behavior</string>
-	<string name="settings_timeline">Timeline</string>
 	<string name="settings_show_replies">Show replies</string>
 	<string name="settings_show_boosts">Show boosts</string>
 	<string name="settings_gif">Play animated avatars and emoji</string>


### PR DESCRIPTION
Closes #210

![Screenshot_2022-11-08-00-10-13-153-edit_org joinmastodon android](https://user-images.githubusercontent.com/6217438/200435635-45810386-531a-43ff-acd9-2042d5e2fe7f.jpg)

Edit: Now using the home_timeline string (“Home timeline”) for the settings section