### PR TITLE
Fix CJK text cut off for category names on Onboarding screen

### DIFF
--- a/mastodon/src/main/res/layout/item_instance_category.xml
+++ b/mastodon/src/main/res/layout/item_instance_category.xml
@@ -4,8 +4,8 @@
 	android:orientation="vertical"
 	android:layout_width="120dp"
 	android:layout_height="72dp"
-	android:paddingTop="13dp"
-	android:paddingBottom="13dp">
+	android:paddingTop="12dp"
+	android:paddingBottom="12dp">
 
 	<ImageView
 		android:id="@+id/emoji"
@@ -17,7 +17,7 @@
 	<TextView
 		android:id="@android:id/text1"
 		android:layout_width="wrap_content"
-		android:layout_height="16dp"
+		android:layout_height="18dp"
 		android:layout_gravity="center_horizontal"
 		android:textAllCaps="true"
 		android:textColor="?android:textColorPrimary"


### PR DESCRIPTION
Fix CJK text cut off for category names on Onboarding screen by reducing padding and increasing TextView height by 2dp.
Please let me know if that would be an OK solution for you.

Before:
![Screenshot_20221108_234136_before](https://user-images.githubusercontent.com/198724/200598162-51247b21-5b5e-4819-b12f-c4e7ad01d3a4.png)

After:
![Screenshot_20221108_234414_after](https://user-images.githubusercontent.com/198724/200598198-78cb9405-b8d6-43af-94a3-6c500e9140c7.png)
