### PR TITLE
Fix button bar layout in onboarding activation for smaller widths

### DIFF
--- a/mastodon/src/main/res/layout-w600dp/button_bar_activation.xml
+++ b/mastodon/src/main/res/layout-w600dp/button_bar_activation.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/button_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?colorBackgroundLight"
+    android:outlineProvider="bounds"
+    android:orientation="horizontal"
+    android:clipToPadding="false"
+    android:elevation="3dp"
+    tools:showIn="@layout/fragment_onboarding_activation">
+
+    <Button
+        android:id="@+id/btn_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        style="?secondaryLargeButtonStyle"
+        android:text="@string/resend" />
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/btn_next"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        style="?primaryLargeButtonStyle"
+        android:text="@string/open_email_app" />
+
+</LinearLayout>

--- a/mastodon/src/main/res/layout/button_bar_activation.xml
+++ b/mastodon/src/main/res/layout/button_bar_activation.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/button_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?colorBackgroundLight"
+    android:clipToPadding="false"
+    android:elevation="3dp"
+    android:orientation="horizontal"
+    android:outlineProvider="bounds"
+    android:gravity="center_vertical"
+    tools:showIn="@layout/fragment_onboarding_activation">
+
+    <Button
+        android:id="@+id/btn_back"
+        style="?secondaryLargeButtonStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="8dp"
+        android:layout_weight="1"
+        android:text="@string/resend" />
+
+    <Button
+        android:id="@+id/btn_next"
+        style="?primaryLargeButtonStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="16dp"
+        android:layout_weight="1"
+        android:text="@string/open_email_app" />
+
+</LinearLayout>

--- a/mastodon/src/main/res/layout/fragment_onboarding_activation.xml
+++ b/mastodon/src/main/res/layout/fragment_onboarding_activation.xml
@@ -51,41 +51,6 @@
 
 	</ScrollView>
 
-	<LinearLayout
-		android:id="@+id/button_bar"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:background="?colorBackgroundLight"
-		android:outlineProvider="bounds"
-		android:orientation="horizontal"
-		android:clipToPadding="false"
-		android:elevation="3dp">
-
-		<Button
-			android:id="@+id/btn_back"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginStart="16dp"
-			android:layout_marginTop="16dp"
-			android:layout_marginBottom="16dp"
-			style="?secondaryLargeButtonStyle"
-			android:text="@string/resend"/>
-
-		<Space
-			android:layout_width="0dp"
-			android:layout_height="1dp"
-			android:layout_weight="1"/>
-
-		<Button
-			android:id="@+id/btn_next"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginEnd="16dp"
-			android:layout_marginTop="16dp"
-			android:layout_marginBottom="16dp"
-			style="?primaryLargeButtonStyle"
-			android:text="@string/open_email_app" />
-
-	</LinearLayout>
+	<include layout="@layout/button_bar_activation" />
 
 </me.grishka.appkit.views.FragmentRootLinearLayout>


### PR DESCRIPTION
Fix the button bar layout in the onboarding activation screen for screens with smaller width by creating separate layouts for default and `w600dp`.

Before

![Screenshot 2022-11-13 125444](https://user-images.githubusercontent.com/1191816/201520544-d20e8142-88a6-4c7d-8ff5-34dbee16d5aa.png)
![Screenshot 2022-11-13 125455](https://user-images.githubusercontent.com/1191816/201520545-197ec0f0-fc8a-49d5-a454-e1e16b9de54d.png)

After

![Screenshot 2022-11-13 125522](https://user-images.githubusercontent.com/1191816/201520576-9929455c-f497-4e67-b05f-4a355d41960c.png)
