### PR TITLE
Add Support for showing "Verified" fields on the Profile | About View

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/gson/IsoInstantTypeAdapter.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/gson/IsoInstantTypeAdapter.java
@@ -25,10 +25,21 @@ public class IsoInstantTypeAdapter extends TypeAdapter<Instant>{
 			in.nextNull();
 			return null;
 		}
-		try{
-			return DateTimeFormatter.ISO_INSTANT.parse(in.nextString(), Instant::from);
-		}catch(DateTimeParseException x){
+		String nextString;
+		try {
+			nextString = in.nextString();
+		}catch(Exception e){
 			return null;
 		}
+
+		try{
+			return DateTimeFormatter.ISO_INSTANT.parse(nextString, Instant::from);
+		}catch(DateTimeParseException x){}
+
+		try{
+			return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(nextString, Instant::from);
+		}catch(DateTimeParseException x){}
+
+		return null;
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileAboutFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileAboutFragment.java
@@ -183,7 +183,7 @@ public class ProfileAboutFragment extends Fragment implements WindowInsetsAwareF
 	}
 
 	private abstract class BaseViewHolder extends BindableViewHolder<AccountField>{
-		private ShapeDrawable background=new ShapeDrawable();
+		protected ShapeDrawable background=new ShapeDrawable();
 
 		public BaseViewHolder(int layout){
 			super(getActivity(), layout, list);
@@ -220,6 +220,10 @@ public class ProfileAboutFragment extends Fragment implements WindowInsetsAwareF
 			super.onBind(item);
 			title.setText(item.parsedName);
 			value.setText(item.parsedValue);
+			if(item.verifiedAt != null){
+				background.getPaint().setARGB(255,213,228, 217);
+				itemView.setBackground(background);
+			}
 		}
 
 		@Override


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1587282/202322976-2d5d6791-4701-4fae-8227-1280fafa1ebd.png)

For at least my server, I'm getting a response back from the `/accounts/:id` endpoint that has value that the client doesn't currently parse:

```
$ curl -s https://hachyderm.io/api/v1/accounts/109343416337534779 | jq '.fields[1].verified_at'
"2022-11-14T19:09:55.195+00:00"
```

This change adds support for formatting via `DateTimeFormatter.ISO_OFFSET_DATE_TIME` as well as the current strategy.

With this in place, the `verifiedAt` property of the field item is populated correctly.

I've naively changed the background color of the view to mimic the color in the ios app which was set here: https://github.com/mastodon/mastodon-ios/pull/564/files#diff-9f9b076de09fb062f0ac69c0392cbce9eece78a09cc0fb68fefd519dfce6760eR4-R10

fixes #125

That said, I didn't go any further to add a checkmark or add proper color theming as I suspect the project maintainers will have opinions about these and will probably be able to add them a lot more quickly than I could.