### PR TITLE
fix the size of the spoiler tag

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -83,7 +83,7 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 					itemView.setClickable(false);
 				}else{
 					spoilerOverlay.setVisibility(View.VISIBLE);
-					text.setVisibility(View.INVISIBLE);
+					text.setVisibility(View.GONE);
 					itemView.setClickable(true);
 				}
 			}else{


### PR DESCRIPTION
Fix the size of a post with a spoiler tag before been opened when the text is longer than the spoiler tag 
The problem with the blank space of the tag having the same size as the final text is some instances allow thousands of characters and the tag can occupy several pages of timeline.

Before:
![before](https://user-images.githubusercontent.com/29210382/202350683-36a3007b-b6a6-4f6f-ac87-194b747a434f.jpg)

After:
![after](https://user-images.githubusercontent.com/29210382/202350706-5bb3e0c3-25f4-4f4f-aafc-fd5d1183e484.jpg)

