### PR TITLE
Omit “middle dot” for screen reader

### DIFF
--- a/mastodon/src/main/res/layout/display_item_header.xml
+++ b/mastodon/src/main/res/layout/display_item_header.xml
@@ -94,6 +94,7 @@
 			android:layout_height="20dp"
 			android:layout_marginLeft="4dp"
 			android:layout_marginRight="4dp"
+			android:importantForAccessibility="no"
 			android:text="·"
 			android:textAppearance="@style/m3_title_small" />
 


### PR DESCRIPTION
The screen reader (tested with TalkBack) used to read aloud the username, “middle dot”, [time left]