### PR TITLE
#196 Report comment tab gains a forward to server switch

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.view.WindowInsets;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import com.squareup.otto.Subscribe;
@@ -28,7 +29,6 @@ import java.util.ArrayList;
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
-import me.grishka.appkit.fragments.ToolbarFragment;
 import me.grishka.appkit.utils.V;
 
 public class ReportCommentFragment extends MastodonToolbarFragment{
@@ -37,6 +37,7 @@ public class ReportCommentFragment extends MastodonToolbarFragment{
 	private Button btn;
 	private View buttonBar;
 	private EditText commentEdit;
+	private Switch forwardSwitch;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -72,6 +73,10 @@ public class ReportCommentFragment extends MastodonToolbarFragment{
 		subtitle.setVisibility(View.GONE);
 		stepCounter.setText(getString(R.string.step_x_of_n, 3, 3));
 
+		forwardSwitch=view.findViewById(R.id.forward);
+		String accountDomain=reportAccount.getDomain();
+		forwardSwitch.setText(getString(R.string.report_comment_forward_to, accountDomain));
+
 		btn=view.findViewById(R.id.btn_next);
 		btn.setOnClickListener(this::onButtonClick);
 		view.findViewById(R.id.btn_back).setOnClickListener(this::onButtonClick);
@@ -102,7 +107,7 @@ public class ReportCommentFragment extends MastodonToolbarFragment{
 		ReportReason reason=ReportReason.valueOf(getArguments().getString("reason"));
 		ArrayList<String> statusIDs=getArguments().getStringArrayList("statusIDs");
 		ArrayList<String> ruleIDs=getArguments().getStringArrayList("ruleIDs");
-		new SendReport(reportAccount.id, reason, statusIDs, ruleIDs, v.getId()==R.id.btn_back ? null : commentEdit.getText().toString(), true)
+		new SendReport(reportAccount.id, reason, statusIDs, ruleIDs, v.getId()==R.id.btn_back ? null : commentEdit.getText().toString(), forwardSwitch.isChecked())
 				.setCallback(new Callback<>(){
 					@Override
 					public void onSuccess(Object result){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
@@ -74,8 +74,8 @@ public class ReportCommentFragment extends MastodonToolbarFragment{
 		stepCounter.setText(getString(R.string.step_x_of_n, 3, 3));
 
 		forwardSwitch=view.findViewById(R.id.forward);
-		String accountDomain=reportAccount.getDomain();
-		forwardSwitch.setText(getString(R.string.report_comment_forward_to, accountDomain));
+		forwardSwitch.setText(getString(R.string.report_comment_forward_to, reportAccount.getDomain()));
+		forwardSwitch.setChecked(true);
 
 		btn=view.findViewById(R.id.btn_next);
 		btn.setOnClickListener(this::onButtonClick);

--- a/mastodon/src/main/res/layout/fragment_report_comment.xml
+++ b/mastodon/src/main/res/layout/fragment_report_comment.xml
@@ -26,6 +26,13 @@
 				android:gravity="top|start"
 				android:minHeight="212dp"/>
 
+			<Switch
+				android:id="@+id/forward"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_margin="16dp"
+				android:gravity="top|start"/>
+
 		</LinearLayout>
 
 	</ScrollView>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
 	<string name="report_choose_posts_subtitle">Select all that apply</string>
 	<string name="report_comment_title">Is there anything else we should know?</string>
 	<string name="report_comment_hint">Additional comments</string>
+	<string name="report_comment_forward_to">Forward to %s</string>
 	<string name="sending_report">Sending report…</string>
 	<string name="report_sent_title">Thanks for reporting, we\'ll look into this.</string>
 	<string name="report_sent_subtitle">While we review this, you can take action against %s.</string>


### PR DESCRIPTION
This switch populates the forward parameter of the SendReport API call.

Allows users to choice to forward the report to the originating server. Defaults to off. Does not persist through a back / forward step (which is consist with the additional comments text box).

Work in Progress draft PR.
Need to check if this prompt is shown to web users who a reporting a local user.