### PR TITLE
Differentiate between “My followers” and other accounts followers for i18n

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -460,9 +460,12 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		followersCount.setText(UiUtils.abbreviateNumber(account.followersCount));
 		followingCount.setText(UiUtils.abbreviateNumber(account.followingCount));
 		postsCount.setText(UiUtils.abbreviateNumber(account.statusesCount));
-		followersLabel.setText(getResources().getQuantityString(R.plurals.followers, (int)Math.min(999, account.followersCount)));
-		followingLabel.setText(getResources().getQuantityString(R.plurals.following, (int)Math.min(999, account.followingCount)));
-		postsLabel.setText(getResources().getQuantityString(R.plurals.posts, (int)Math.min(999, account.statusesCount)));
+		final int followingResId = isSelf ? R.plurals.my_following : R.plurals.following;
+		final int followersResId = isSelf ? R.plurals.my_followers : R.plurals.followers;
+		final int postsResId = isSelf ? R.plurals.my_posts : R.plurals.posts;
+		followersLabel.setText(getResources().getQuantityString(followersResId, (int)Math.min(999, account.followersCount)));
+		followingLabel.setText(getResources().getQuantityString(followingResId, (int)Math.min(999, account.followingCount)));
+		postsLabel.setText(getResources().getQuantityString(postsResId, (int)Math.min(999, account.statusesCount)));
 
 		UiUtils.loadCustomEmojiInTextView(name);
 		UiUtils.loadCustomEmojiInTextView(bio);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowerListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowerListFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.HeaderPaginationRequest;
 import org.joinmastodon.android.api.requests.accounts.GetAccountFollowers;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
 
 public class FollowerListFragment extends AccountRelatedAccountListFragment{
@@ -12,7 +13,9 @@ public class FollowerListFragment extends AccountRelatedAccountListFragment{
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
-		setSubtitle(getResources().getQuantityString(R.plurals.x_followers, (int)(account.followersCount%1000), account.followersCount));
+		final boolean isSelf = AccountSessionManager.getInstance().isSelf(accountID, account);
+		final int followersCountResId = isSelf ? R.plurals.my_x_followers : R.plurals.x_followers;
+		setSubtitle(getResources().getQuantityString(followersCountResId, (int)(account.followersCount%1000), account.followersCount));
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowingListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowingListFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.HeaderPaginationRequest;
 import org.joinmastodon.android.api.requests.accounts.GetAccountFollowing;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
 
 public class FollowingListFragment extends AccountRelatedAccountListFragment{
@@ -12,7 +13,9 @@ public class FollowingListFragment extends AccountRelatedAccountListFragment{
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
-		setSubtitle(getResources().getQuantityString(R.plurals.x_following, (int)(account.followingCount%1000), account.followingCount));
+		final boolean isSelf = AccountSessionManager.getInstance().isSelf(accountID, account);
+		final int followingCountResId = isSelf ? R.plurals.my_x_following : R.plurals.x_following;
+		setSubtitle(getResources().getQuantityString(followingCountResId, (int)(account.followingCount%1000), account.followingCount));
 	}
 
 	@Override

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -38,14 +38,29 @@
 		<item quantity="one">follower</item>
 		<item quantity="other">followers</item>
 	</plurals>
+	<plurals name="my_followers">
+		<item quantity="one">follower</item>
+		<item quantity="other">followers</item>
+	</plurals>
+
 	<plurals name="following">
 		<item quantity="one">following</item>
 		<item quantity="other">following</item>
 	</plurals>
+	<plurals name="my_following">
+		<item quantity="one">following</item>
+		<item quantity="other">following</item>
+	</plurals>
+
 	<plurals name="posts">
 		<item quantity="one">post</item>
 		<item quantity="other">posts</item>
 	</plurals>
+	<plurals name="my_posts">
+		<item quantity="one">post</item>
+		<item quantity="other">posts</item>
+	</plurals>
+
 	<string name="posts">Posts</string>
 	<string name="posts_and_replies">Posts and Replies</string>
 	<string name="media">Media</string>
@@ -325,7 +340,16 @@
 		<item quantity="one">%,d follower</item>
 		<item quantity="other">%,d followers</item>
 	</plurals>
+	<plurals name="my_x_followers">
+		<item quantity="one">%,d follower</item>
+		<item quantity="other">%,d followers</item>
+	</plurals>
+
 	<plurals name="x_following">
+		<item quantity="one">%,d following</item>
+		<item quantity="other">%,d following</item>
+	</plurals>
+	<plurals name="my_x_following">
 		<item quantity="one">%,d following</item>
 		<item quantity="other">%,d following</item>
 	</plurals>


### PR DESCRIPTION
Some languages, like german, could profit from the distinction whether a label is shown in the context of the current user's profile page or a different user's profile page.
This way we can use more clear and fitting translations.

This PR makes it possible to have different strings for "Posts", "Following", and "Followers" in the ProfileFragment, as well as FollowerListFragment and FollowingListFragment, depending on whether a user is currently looking at their own profile or that of another user. 

This doesn't touch the UI of Profile cards in the "For You" section or in the notification area, because there we will only ever see other users profiles and never our own.