### PR TITLE
Remove check that only applies CW when replying to self

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -491,7 +491,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 				ignoreSelectionChanges=true;
 				mainEditText.setSelection(mainEditText.length());
 				ignoreSelectionChanges=false;
-				if(!TextUtils.isEmpty(replyTo.spoilerText) && AccountSessionManager.getInstance().isSelf(accountID, replyTo.account)){
+				if(!TextUtils.isEmpty(replyTo.spoilerText)){
 					hasSpoiler=true;
 					spoilerEdit.setVisibility(View.VISIBLE);
 					spoilerEdit.setText(replyTo.spoilerText);


### PR DESCRIPTION
Previously when a user replied to a post with a content warning that was not their own, the content warning would not be applied

This change makes it so that when a user replies to ANY post, not just their own, the content warning is automatically applied, in line with how the web application currently functions.

This fixes #113, which was marked as `wontfix` with no real explanation.