### PR TITLE
The Mastodon server does not currently use URL_SAFE encoding on its s…

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -162,7 +162,7 @@ public class PushSubscriptionManager{
 						@Override
 						public void onSuccess(PushSubscription result){
 							MastodonAPIController.runInBackground(()->{
-								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.URL_SAFE));
+								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.DEFAULT));
 
 								AccountSession session=AccountSessionManager.getInstance().tryGetAccount(accountID);
 								if(session==null)


### PR DESCRIPTION
…erverKey. Using URL_SAFE in this client means the client will crash for any server that uses a key that generates a Mime64 string containing a "+" or "/".  This change removes the URL_SAFE logic. See: https://github.com/mastodon/mastodon-android/issues/483