### PR TITLE
Second fix for MIME64 inconsistency in serverKey.

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -164,7 +164,7 @@ public class PushSubscriptionManager{
 							MastodonAPIController.runInBackground(()->{
 								result.serverKey=result.serverKey.replace('/','_');
 								result.serverKey=result.serverKey.replace('+','-');
-								deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.URL_SAFE));
+								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.URL_SAFE));
 
 								AccountSession session=AccountSessionManager.getInstance().tryGetAccount(accountID);
 								if(session==null)

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -162,7 +162,9 @@ public class PushSubscriptionManager{
 						@Override
 						public void onSuccess(PushSubscription result){
 							MastodonAPIController.runInBackground(()->{
-								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.DEFAULT));
+								result.serverKey=result.serverKey.replace('/','_');
+								result.serverKey=result.serverKey.replace('+','-');
+								deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.URL_SAFE));
 
 								AccountSession session=AccountSessionManager.getInstance().tryGetAccount(accountID);
 								if(session==null)

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -162,7 +162,7 @@ public class PushSubscriptionManager{
 						@Override
 						public void onSuccess(PushSubscription result){
 							MastodonAPIController.runInBackground(()->{
-								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.URL_SAFE));
+								serverKey=deserializeRawPublicKey(Base64.decode(result.serverKey, Base64.DEFAULT));
 
 								AccountSession session=AccountSessionManager.getInstance().tryGetAccount(accountID);
 								if(session==null)


### PR DESCRIPTION
The previous fix https://github.com/mastodon/mastodon-android/pull/486 would break any connections to any instances using WEB_SAFE MIME64 encoding on the serverKey, which actually appears to be the usual case.
This update reverts to the previous logic, but also converts standard MIME64 characters ('/' and '+') to their WEB_SAFE equivalents.
This ensures the standard case of WEB_SAFE BASE64 serverKeys and the anomalous case of DEFAULT BASE64 keys both work.