### PR TITLE
Fix wrong "hasSpoiler" value on restore

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -333,6 +333,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		spoilerBg.setDrawableByLayerId(R.id.right_drawable, new SpoilerStripesDrawable());
 		spoilerEdit.setBackground(spoilerBg);
 		if((savedInstanceState!=null && savedInstanceState.getBoolean("hasSpoiler", false)) || hasSpoiler){
+			hasSpoiler=true;
 			spoilerEdit.setVisibility(View.VISIBLE);
 			spoilerBtn.setSelected(true);
 		}else if(editingStatus!=null && !TextUtils.isEmpty(editingStatus.spoilerText)){


### PR DESCRIPTION
There's a bug where, when restoring the saved ComposeFragment instance twice, the spoiler would disappear.
Turns out this is the case because the "hasSpoiler" value isn't properly restored when loading the spoiler back into place for the first time – so the second time, "hasSpoiler" will be `false` even though there would be a spoiler value to restore.