### PR TITLE
Enable scrolling to top by tapping Notifications toolbar

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
@@ -72,6 +72,18 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 
 		tabLayout.setTabTextSize(V.dp(16));
 		tabLayout.setTabTextColors(UiUtils.getThemeColor(getActivity(), R.attr.colorTabInactive), UiUtils.getThemeColor(getActivity(), android.R.attr.textColorPrimary));
+		tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+			@Override
+			public void onTabSelected(TabLayout.Tab tab) {}
+
+			@Override
+			public void onTabUnselected(TabLayout.Tab tab) {}
+
+			@Override
+			public void onTabReselected(TabLayout.Tab tab) {
+				scrollToTop();
+			}
+		});
 
 		pager.setOffscreenPageLimit(4);
 		pager.setAdapter(new DiscoverPagerAdapter());
@@ -137,6 +149,7 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 	protected void updateToolbar(){
 		super.updateToolbar();
 		getToolbar().setOutlineProvider(null);
+		getToolbar().setOnClickListener(v->scrollToTop());
 	}
 
 	private NotificationsListFragment getFragmentForPage(int page){


### PR DESCRIPTION
In case this wasn't deliberately left out: This enabled the same behavior as in Profile and Discover – scrolling to the top by clicking the toolbar or the selected tab.