### PR TITLE
Bigger hitbox for items in compose toolbar

### DIFF
--- a/mastodon/src/main/res/layout/fragment_compose.xml
+++ b/mastodon/src/main/res/layout/fragment_compose.xml
@@ -165,16 +165,16 @@
 		android:background="?colorBackgroundLightest"
 		android:elevation="2dp"
 		android:outlineProvider="bounds"
-		android:paddingLeft="16dp"
-		android:paddingRight="16dp"
+		android:paddingHorizontal="10dp"
+		android:layout_marginEnd="6dp"
 		android:layoutDirection="locale">
 
 		<ImageButton
 			android:id="@+id/btn_media"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_marginEnd="24dp"
-			android:background="?android:attr/selectableItemBackgroundBorderless"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_marginEnd="12dp"
+			android:background="?android:attr/actionBarItemBackground"
 			android:padding="0px"
 			android:tint="@color/compose_button"
 			android:tintMode="src_in"
@@ -184,10 +184,10 @@
 
 		<ImageButton
 			android:id="@+id/btn_poll"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_marginEnd="24dp"
-			android:background="?android:attr/selectableItemBackgroundBorderless"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_marginEnd="12dp"
+			android:background="?android:attr/actionBarItemBackground"
 			android:padding="0px"
 			android:tint="@color/compose_button"
 			android:tintMode="src_in"
@@ -197,10 +197,10 @@
 
 		<ImageButton
 			android:id="@+id/btn_emoji"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_marginEnd="24dp"
-			android:background="?android:attr/selectableItemBackgroundBorderless"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_marginEnd="12dp"
+			android:background="?android:attr/actionBarItemBackground"
 			android:padding="0px"
 			android:tint="@color/compose_button"
 			android:tintMode="src_in"
@@ -210,10 +210,10 @@
 
 		<ImageButton
 			android:id="@+id/btn_spoiler"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_marginEnd="24dp"
-			android:background="?android:attr/selectableItemBackgroundBorderless"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_marginEnd="12dp"
+			android:background="?android:attr/actionBarItemBackground"
 			android:padding="0px"
 			android:tint="@color/compose_button"
 			android:tintMode="src_in"
@@ -223,10 +223,10 @@
 
 		<ImageButton
 			android:id="@+id/btn_visibility"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_marginEnd="24dp"
-			android:background="?android:attr/selectableItemBackgroundBorderless"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_marginEnd="12dp"
+			android:background="?android:attr/actionBarItemBackground"
 			android:padding="0px"
 			android:tint="@color/compose_button"
 			android:tintMode="src_in"


### PR DESCRIPTION
The compose toolbar's ImageButtons are only 24dp in width and height, but their ripple background suggests otherwise - which is not great for accessibility as the buttons are really easy to miss, leaving the user to wonder why.

![image](https://user-images.githubusercontent.com/6217438/214057438-a5be935f-f113-49d9-82cc-0faf260bdf50.png)

Using "actionBarItemBackground" instead of the "selectableItemBackgroundBorderless" makes the ripple more adjacent to the actual hitbox, which I have therefore increased to 36dp:

![image](https://user-images.githubusercontent.com/6217438/214057673-fd508f4e-7530-465a-9712-1c657c4ae615.png)
