### PR TITLE
fix: typos

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
@@ -45,7 +45,7 @@ public class Instance extends BaseModel{
 	@RequiredField
 	public String version;
 	/**
-	 * Primary langauges of the website and its staff.
+	 * Primary languages of the website and its staff.
 	 */
 //	@RequiredField
 	public List<String> languages;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/tabs/TabLayout.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/tabs/TabLayout.java
@@ -602,7 +602,7 @@ public class TabLayout extends HorizontalScrollView {
    * <p>If the tab indicator color is not {@code Color.TRANSPARENT}, the indicator will be wrapped
    * and tinted right before it is drawn by {@link SlidingTabIndicator#draw(Canvas)}. If you'd like
    * the inherent color or the tinted color of a custom drawable to be used, make sure this color is
-   * set to {@code Color.TRANSPARENT} to avoid your color/tint being overriden.
+   * set to {@code Color.TRANSPARENT} to avoid your color/tint being overridden.
    *
    * @param color color to use for the indicator
    * @attr ref com.google.android.material.R.styleable#TabLayout_tabIndicatorColor


### PR DESCRIPTION
Fixes two typos in comments found via `codespell  -S ./mastodon/src/main/res,./fastlane,./mastodon/src/main/java/com`.