### PR TITLE
clickable links: add "hold to copy" action

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -113,6 +113,8 @@ public class ClickableLinksDelegate {
 	}
 
 	Runnable copyTextToClipboard = () -> {
+		//if target is not a link, don't copy
+		if (selectedSpan.getType() != LinkSpan.Type.URL) return;
 		//copy link text to clipboard
 		ClipboardManager clipboard = (ClipboardManager) view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
 		clipboard.setPrimaryClip(ClipData.newPlainText("", selectedSpan.getLink()));

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -45,7 +45,7 @@ public class ClickableLinksDelegate {
 		//reset view
 		resetAndInvalidate();
 	};
-	
+
 	public ClickableLinksDelegate(TextView view) {
 		this.view=view;
 		hlPaint=new Paint();
@@ -134,7 +134,7 @@ public class ClickableLinksDelegate {
 		selectedSpan=null;
 		view.invalidate();
 	}
-	
+
 	public void onDraw(Canvas canvas){
 		if(hlPath!=null){
 			canvas.save();

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -1,11 +1,15 @@
 package org.joinmastodon.android.ui.text;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.CornerPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.Build;
 import android.os.Handler;
 import android.text.Layout;
 import android.text.Spanned;
@@ -109,9 +113,15 @@ public class ClickableLinksDelegate {
 	}
 
 	Runnable copyTextToClipboard = () -> {
-		//TODO actually copy to clipboard
-		//TODO think about removing toast, system > A12 (?) has a built-in popup
-		Toast.makeText(view.getContext(), "copied to clipboard", Toast.LENGTH_SHORT).show();
+		//copy link text to clipboard
+		ClipboardManager clipboard = (ClipboardManager) view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+		clipboard.setPrimaryClip(ClipData.newPlainText("", selectedSpan.getLink()));
+		//show toast, android from S_V2 on has built-in popup, as documented in
+		//https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+			Toast.makeText(view.getContext(), "Copied", Toast.LENGTH_SHORT).show();
+		}
+		//reset view
 		resetAndInvalidate();
 	};
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -15,7 +15,6 @@ import android.text.Spanned;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.SoundEffectConstants;
-import android.view.ViewConfiguration;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -27,12 +26,12 @@ import me.grishka.appkit.utils.V;
 
 public class ClickableLinksDelegate {
 
-	private Paint hlPaint;
+	final private Paint hlPaint;
 	private Path hlPath;
 	private LinkSpan selectedSpan;
-	private TextView view;
+	final private TextView view;
 
-	GestureDetector gestureDetector;
+	final GestureDetector gestureDetector;
 
 	public ClickableLinksDelegate(TextView view) {
 		this.view=view;
@@ -82,8 +81,7 @@ public class ClickableLinksDelegate {
 				return false;
 			}
 			CharSequence text=view.getText();
-			if(text instanceof Spanned){
-				Spanned s=(Spanned)text;
+			if(text instanceof Spanned s){
 				LinkSpan[] spans=s.getSpans(0, s.length()-1, LinkSpan.class);
 				if(spans.length>0){
 					for(LinkSpan span:spans){
@@ -100,7 +98,6 @@ public class ClickableLinksDelegate {
 							}
 							hlPath=new Path();
 							selectedSpan=span;
-							view.postDelayed(copyTextToClipboard, ViewConfiguration.getLongPressTimeout());
 							hlPaint.setColor((span.getColor() & 0x00FFFFFF) | 0x33000000);
 							//l.getSelectionPath(start, end, hlPath);
 							for(int j=lstart;j<=lend;j++){
@@ -132,7 +129,6 @@ public class ClickableLinksDelegate {
 		@Override
 		public boolean onSingleTapUp(@NonNull MotionEvent event) {
 			if(selectedSpan!=null){
-				view.removeCallbacks(copyTextToClipboard);
 				view.playSoundEffect(SoundEffectConstants.CLICK);
 				selectedSpan.onClick(view.getContext());
 				resetAndInvalidate();

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -44,11 +44,16 @@ public class ClickableLinksDelegate {
 
 	public boolean onTouch(MotionEvent event) {
 		if(event.getAction()==MotionEvent.ACTION_CANCEL){
+			// the gestureDetector does not provide a callback for CANCEL, therefore:
+			// remove background color of view before passing event to gestureDetector
 			resetAndInvalidate();
 		}
 		return gestureDetector.onTouchEvent(event);
 	}
 
+	/**
+	 * remove highlighting from span and let the system redraw the view
+	 */
 	private void resetAndInvalidate() {
 		hlPath=null;
 		selectedSpan=null;
@@ -64,6 +69,12 @@ public class ClickableLinksDelegate {
 		}
 	}
 
+	/**
+	 * GestureListener for spans that represent URLs.
+	 * onDown: on start of touch event, set highlighting
+	 * onSingleTapUp: when there was a (short) tap, call onClick and reset highlighting
+	 * onLongPress: copy URL to clipboard, let user know, reset highlighting
+	 */
 	private class LinkGestureListener extends GestureDetector.SimpleOnGestureListener {
 		@Override
 		public boolean onDown(@NonNull MotionEvent event) {

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -19,6 +19,8 @@ import android.view.ViewConfiguration;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.joinmastodon.android.R;
+
 import me.grishka.appkit.utils.V;
 
 public class ClickableLinksDelegate {
@@ -28,6 +30,21 @@ public class ClickableLinksDelegate {
 	private LinkSpan selectedSpan;
 	private TextView view;
 	private final Handler longClickHandler = new Handler();
+
+	private final Runnable copyTextToClipboard = () -> {
+		//if target is not a link, don't copy
+		if (selectedSpan.getType() != LinkSpan.Type.URL) return;
+		//copy link text to clipboard
+		ClipboardManager clipboard = (ClipboardManager) view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+		clipboard.setPrimaryClip(ClipData.newPlainText("", selectedSpan.getLink()));
+		//show toast, android from S_V2 on has built-in popup, as documented in
+		//https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+			Toast.makeText(view.getContext(), R.string.text_copied, Toast.LENGTH_SHORT).show();
+		}
+		//reset view
+		resetAndInvalidate();
+	};
 	
 	public ClickableLinksDelegate(TextView view) {
 		this.view=view;
@@ -111,21 +128,6 @@ public class ClickableLinksDelegate {
 		}
 		return false;
 	}
-
-	Runnable copyTextToClipboard = () -> {
-		//if target is not a link, don't copy
-		if (selectedSpan.getType() != LinkSpan.Type.URL) return;
-		//copy link text to clipboard
-		ClipboardManager clipboard = (ClipboardManager) view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-		clipboard.setPrimaryClip(ClipData.newPlainText("", selectedSpan.getLink()));
-		//show toast, android from S_V2 on has built-in popup, as documented in
-		//https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
-		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-			Toast.makeText(view.getContext(), "Copied", Toast.LENGTH_SHORT).show();
-		}
-		//reset view
-		resetAndInvalidate();
-	};
 
 	private void resetAndInvalidate() {
 		hlPath=null;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/ClickableLinksDelegate.java
@@ -10,7 +10,6 @@ import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.os.Build;
-import android.os.Handler;
 import android.text.Layout;
 import android.text.Spanned;
 import android.view.MotionEvent;
@@ -29,7 +28,6 @@ public class ClickableLinksDelegate {
 	private Path hlPath;
 	private LinkSpan selectedSpan;
 	private TextView view;
-	private final Handler longClickHandler = new Handler();
 
 	private final Runnable copyTextToClipboard = () -> {
 		//if target is not a link, don't copy
@@ -88,7 +86,7 @@ public class ClickableLinksDelegate {
 							}
 							hlPath=new Path();
 							selectedSpan=span;
-							longClickHandler.postDelayed(copyTextToClipboard, ViewConfiguration.getLongPressTimeout());
+							view.postDelayed(copyTextToClipboard, ViewConfiguration.getLongPressTimeout());
 							hlPaint.setColor((span.getColor() & 0x00FFFFFF) | 0x33000000);
 							//l.getSelectionPath(start, end, hlPath);
 							for(int j=lstart;j<=lend;j++){
@@ -116,7 +114,7 @@ public class ClickableLinksDelegate {
 			}
 		}
 		if(event.getAction()==MotionEvent.ACTION_UP && selectedSpan!=null){
-			longClickHandler.removeCallbacks(copyTextToClipboard);
+			view.removeCallbacks(copyTextToClipboard);
 			view.playSoundEffect(SoundEffectConstants.CLICK);
 			selectedSpan.onClick(view.getContext());
 			resetAndInvalidate();


### PR DESCRIPTION
I have added a small change to the ClickableLink views, allowing a new action to copy the link text rather than opening it.

I also did some minor refactoring in the affected file, because I didn't want to copy existing (and already reused) code a third time.

Resolves https://github.com/mastodon/mastodon-android/issues/537
