### PR TITLE
fix(search): check for empty queries

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -236,7 +236,7 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 	}
 
 	public void setQuery(String q){
-		if(Objects.equals(q, currentQuery))
+		if(Objects.equals(q, currentQuery) || q.isBlank())
 			return;
 		if(currentRequest!=null){
 			currentRequest.cancel();


### PR DESCRIPTION
Fixes an error message, which would appear, if the search query was blank.

![Example of the error message](https://user-images.githubusercontent.com/63370021/225947363-63511e22-72f4-4302-9b04-6e3e4f17bfbf.png)
