### PR TITLE
[build] Updated AGP and gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "com.android.tools.build:gradle:7.1.3"
+		classpath 'com.android.tools.build:gradle:7.4.2'
 		classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 13 11:33:43 MSK 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description:
This PR updates the AGP version from `7.1.3` to `7.4.2` and Gradle wrapper from `7.3.3` to `7.5`.

### Changes:
- Bumped AGP version from `7.1.3` -> `7.4.2`
- Bumped Gradle version from `7.3.3` -> `7.5`

### Testing:
- Tested build locally `./gradlew assembleRelease` 

