### PR TITLE
Fix wrong tab being selected on restore

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -145,6 +145,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		notificationsFragment=(NotificationsFragment) getChildFragmentManager().getFragment(savedInstanceState, "notificationsFragment");
 		profileFragment=(ProfileFragment) getChildFragmentManager().getFragment(savedInstanceState, "profileFragment");
 		currentTab=savedInstanceState.getInt("selectedTab");
+		tabBar.selectTab(currentTab);
 		Fragment current=fragmentForTab(currentTab);
 		getChildFragmentManager().beginTransaction()
 				.hide(homeTimelineFragment)


### PR DESCRIPTION
When restoring the HomeFragment, the correct tab gets displayed, but the tab doesn't get selected in the tab bar. This patch fixed it.