### PR TITLE
Fix crash when searching for Hashtags on Akkoma servers

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -98,6 +98,12 @@ public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> impl
 		@Override
 		public void onBind(Hashtag item){
 			title.setText('#'+item.name);
+			if (item.history == null || item.history.isEmpty()) {
+				subtitle.setText(null);
+				chart.setVisibility(View.GONE);
+				return;
+			}
+			chart.setVisibility(View.VISIBLE);
 			int numPeople=item.history.get(0).accounts;
 			if(item.history.size()>1)
 				numPeople+=item.history.get(1).accounts;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HashtagStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HashtagStatusDisplayItem.java
@@ -1,6 +1,7 @@
 package org.joinmastodon.android.ui.displayitems;
 
 import android.content.Context;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -37,6 +38,12 @@ public class HashtagStatusDisplayItem extends StatusDisplayItem{
 		public void onBind(HashtagStatusDisplayItem _item){
 			Hashtag item=_item.tag;
 			title.setText('#'+item.name);
+			if (item.history == null || item.history.isEmpty()) {
+				subtitle.setText(null);
+				chart.setVisibility(View.GONE);
+				return;
+			}
+			chart.setVisibility(View.VISIBLE);
 			int numPeople=item.history.get(0).accounts;
 			if(item.history.size()>1)
 				numPeople+=item.history.get(1).accounts;


### PR DESCRIPTION
closes mastodon#468
closes sk22#523

Adds null and isEmpty checks for `history` in `Trending-`/`HashtagStatusDisplayItem`, so Mastodon will display only the hashtag name without the trending history information instead of crashing.