### PR TITLE
Clickability fix of hashtags in right-to-left scripts

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -47,6 +47,7 @@ public class HtmlParser{
 					")";
 	public static final Pattern URL_PATTERN=Pattern.compile(VALID_URL_PATTERN_STRING, Pattern.CASE_INSENSITIVE);
 	private static Pattern EMOJI_CODE_PATTERN=Pattern.compile(":([\\w]+):");
+	private static final char LEFT_TO_RIGHT_MARK = '\u200E';
 
 	private HtmlParser(){}
 
@@ -86,7 +87,12 @@ public class HtmlParser{
 			@Override
 			public void head(@NonNull Node node, int depth){
 				if(node instanceof TextNode textNode){
-					ssb.append(textNode.text());
+					String text = textNode.text();
+					boolean isHashtag = ssb.length() > 0 && ssb.charAt(ssb.length() - 1) == '#'
+							&& !text.isEmpty() && Character.isLetter(text.charAt(0));
+					if (isHashtag)
+						ssb.append(LEFT_TO_RIGHT_MARK);
+					ssb.append(text);
 				}else if(node instanceof Element el){
 					switch(el.nodeName()){
 						case "a" -> {


### PR DESCRIPTION
closes #583 

Adds [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) on parsing hashtags, so the text rendering and spans work correctly.