### PR TITLE
Fix poll not updating content status when boosted

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
@@ -224,7 +224,7 @@ public abstract class StatusListFragment extends BaseStatusListFragment<Status>{
 			for(Status status:data){
 				Status contentStatus=status.getContentStatus();
 				if(contentStatus.poll!=null && contentStatus.poll.id.equals(ev.poll.id)){
-					updatePoll(status.id, status, ev.poll);
+					updatePoll(status.id, contentStatus, ev.poll);
 				}
 			}
 		}


### PR DESCRIPTION
When voting on polls that got boosted into your timeline and then tapping it to open the thread, the poll appears as if you hadn't already voted, and allows to (try to - it'll fail with a validation error) vote again. This fixes the issue by passing the `contentStatus` down to `updatePoll` (which just replaces the `poll` property of that status with the updated one).