### PR TITLE
Fixed Japanese locale mistake "n minutes ago"

### DIFF
--- a/mastodon/src/main/res/values-ja-rJP/strings.xml
+++ b/mastodon/src/main/res/values-ja-rJP/strings.xml
@@ -550,7 +550,7 @@
 	<string name="accounts_matching_string">「%s」を含む人々</string>
 	<!-- Shown in the post header. Please keep it short -->
 	<string name="time_seconds_ago_short">%d 秒前</string>
-	<string name="time_minutes_ago_short">%d か月前</string>
+	<string name="time_minutes_ago_short">%d 分前</string>
 	<string name="time_hours_ago_short">%d 時間前</string>
 	<string name="time_days_ago_short">%d 日前</string>
 </resources>


### PR DESCRIPTION
nヶ月前: n months ago
n分前: n minutes ago