### PR TITLE
Don't display empty image preview if thumbnail image is null

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/LinkCardStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/LinkCardStatusDisplayItem.java
@@ -77,7 +77,10 @@ public class LinkCardStatusDisplayItem extends StatusDisplayItem{
 				crossfadeDrawable.setBlurhashDrawable(card.blurhashPlaceholder);
 				crossfadeDrawable.setCrossfadeAlpha(item.status.spoilerRevealed ? 0f : 1f);
 				photo.setImageDrawable(crossfadeDrawable);
+				photo.setVisibility(View.VISIBLE);
 				didClear=false;
+			} else {
+				photo.setVisibility(View.GONE);
 			}
 		}
 

--- a/mastodon/src/main/res/layout/display_item_link_card.xml
+++ b/mastodon/src/main/res/layout/display_item_link_card.xml
@@ -8,14 +8,14 @@
 	<org.joinmastodon.android.ui.views.MaxWidthFrameLayout
 		android:id="@+id/inner"
 		android:layout_width="match_parent"
-		android:layout_height="250dp"
+		android:layout_height="match_parent"
 		android:layout_gravity="center_horizontal"
 		android:foreground="?android:selectableItemBackground"
 		android:maxWidth="400dp">
 		<ImageView
 			android:id="@+id/photo"
 			android:layout_width="match_parent"
-			android:layout_height="match_parent"
+			android:layout_height="250dp"
 			android:scaleType="centerCrop"
 			tools:src="#0f0"/>
 		<LinearLayout


### PR DESCRIPTION
When link card doesn't have a thumbnail it will render an empty space. This PR address the issue. See screenshot.

<img width="439" alt="Mastodon" src="https://github.com/mastodon/mastodon-android/assets/37196762/700ec8b8-a086-4435-b454-18b4a657f5a4">
