### PR TITLE
Do not assume languages array will contain entries

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
@@ -117,7 +117,7 @@ public class Instance extends BaseModel{
 		ci.domain=uri;
 		ci.normalizedDomain=IDN.toUnicode(uri);
 		ci.description=Html.fromHtml(shortDescription).toString().trim();
-		if(languages!=null){
+		if(languages!=null&&languages.size()>0){
 			ci.language=languages.get(0);
 			ci.languages=languages;
 		}else{


### PR DESCRIPTION
I noticed this while testing the Mastodon app with Calckey / Firefish. The Mastodon app does work on iOS but on Android this causes a crash before signup/sign-in.

I propose to add an additional array length check to ensure the languages array is not empty in order to prevent this crash.