### PR TITLE
Call BaseModel.postprocess() from GSON and Parceler deserialization.

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/CacheController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/CacheController.java
@@ -9,6 +9,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import com.google.gson.JsonSyntaxException;
+
 import org.joinmastodon.android.BuildConfig;
 import org.joinmastodon.android.MastodonApp;
 import org.joinmastodon.android.api.requests.notifications.GetNotifications;
@@ -143,7 +145,6 @@ public class CacheController{
 							String newMaxID;
 							do{
 								Notification ntf=MastodonAPIController.gson.fromJson(cursor.getString(0), Notification.class);
-								ntf.postprocess();
 								newMaxID=ntf.id;
 								result.add(ntf);
 							}while(cursor.moveToNext());
@@ -152,7 +153,7 @@ public class CacheController{
 							uiHandler.post(()->callback.onSuccess(new PaginatedResponse<>(result, _newMaxID)));
 							return;
 						}
-					}catch(IOException x){
+					}catch(JsonSyntaxException x){
 						Log.w(TAG, "getNotifications: corrupted notification object in database", x);
 					}
 				}
@@ -227,7 +228,6 @@ public class CacheController{
 				List<SearchResult> results=new ArrayList<>();
 				while(cursor.moveToNext()){
 					SearchResult result=MastodonAPIController.gson.fromJson(cursor.getString(0), SearchResult.class);
-					result.postprocess();
 					results.add(result);
 				}
 				uiHandler.post(()->callback.accept(results));

--- a/mastodon/src/main/java/org/joinmastodon/android/api/MastodonAPIRequest.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/MastodonAPIRequest.java
@@ -6,23 +6,22 @@ import android.net.Uri;
 import android.util.Log;
 import android.util.Pair;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.StringRes;
+
 import com.google.gson.reflect.TypeToken;
 
 import org.joinmastodon.android.BuildConfig;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
-import org.joinmastodon.android.model.BaseModel;
 import org.joinmastodon.android.model.Token;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.StringRes;
 import me.grishka.appkit.api.APIRequest;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
@@ -164,36 +163,7 @@ public abstract class MastodonAPIRequest<T> extends APIRequest<T>{
 	}
 
 	@CallSuper
-	public void validateAndPostprocessResponse(T respObj, Response httpResponse) throws IOException{
-		if(respObj instanceof BaseModel){
-			((BaseModel) respObj).postprocess();
-		}else if(respObj instanceof List){
-			if(removeUnsupportedItems){
-				Iterator<?> itr=((List<?>) respObj).iterator();
-				while(itr.hasNext()){
-					Object item=itr.next();
-					if(item instanceof BaseModel){
-						try{
-							((BaseModel) item).postprocess();
-						}catch(ObjectValidationException x){
-							Log.w(TAG, "Removing invalid object from list", x);
-							itr.remove();
-						}
-					}
-				}
-				for(Object item:((List<?>) respObj)){
-					if(item instanceof BaseModel){
-						((BaseModel) item).postprocess();
-					}
-				}
-			}else{
-				for(Object item:((List<?>) respObj)){
-					if(item instanceof BaseModel)
-						((BaseModel) item).postprocess();
-				}
-			}
-		}
-	}
+	public void validateAndPostprocessResponse(T respObj, Response httpResponse) throws IOException{}
 
 	void onError(ErrorResponse err){
 		if(!canceled)

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -10,6 +10,8 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 
+import com.google.gson.JsonSyntaxException;
+
 import org.joinmastodon.android.BuildConfig;
 import org.joinmastodon.android.MastodonApp;
 import org.joinmastodon.android.api.requests.notifications.RegisterForPushNotifications;
@@ -45,7 +47,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyAgreement;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -323,14 +324,12 @@ public class PushSubscriptionManager{
 			Log.e(TAG, "decryptNotification: error decrypting payload", x);
 			return null;
 		}
-		PushNotification notification=MastodonAPIController.gson.fromJson(decryptedStr, PushNotification.class);
 		try{
-			notification.postprocess();
-		}catch(IOException x){
+			return MastodonAPIController.gson.fromJson(decryptedStr, PushNotification.class);
+		}catch(JsonSyntaxException x){
 			Log.e(TAG, "decryptNotification: error verifying notification object", x);
 			return null;
 		}
-		return notification;
 	}
 
 	private byte[] deriveKey(byte[] firstSalt, byte[] secondSalt, byte[] info, int length) throws NoSuchAlgorithmException, InvalidKeyException{

--- a/mastodon/src/main/java/org/joinmastodon/android/api/gson/BaseModelTypeAdapterFactory.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/gson/BaseModelTypeAdapterFactory.java
@@ -1,0 +1,37 @@
+package org.joinmastodon.android.api.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import org.joinmastodon.android.model.BaseModel;
+
+import java.io.IOException;
+
+public class BaseModelTypeAdapterFactory implements TypeAdapterFactory{
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type){
+		if(!BaseModel.class.isAssignableFrom(type.getRawType())){
+			return null;
+		}
+
+		final TypeAdapter<T> delegate=gson.getDelegateAdapter(this, type);
+		return new TypeAdapter<>(){
+			@Override
+			public void write(JsonWriter out, T value) throws IOException{
+				delegate.write(out, value);
+			}
+
+			@Override
+			public T read(JsonReader in) throws IOException{
+				T baseModel=delegate.read(in);
+				if (baseModel != null)
+					((BaseModel) baseModel).postprocess();
+				return baseModel;
+			}
+		};
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/api/gson/OptionalItemListDeserializer.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/gson/OptionalItemListDeserializer.java
@@ -1,0 +1,33 @@
+package org.joinmastodon.android.api.gson;
+
+import android.util.Log;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OptionalItemListDeserializer implements JsonDeserializer<List<?>> {
+
+    private static final String TAG = "OptionalBaseModelListTypeAdapterFactory";
+
+    @Override
+    public List<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        Type valueType = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
+
+        List<Object> list = new ArrayList<>();
+        for (JsonElement item : json.getAsJsonArray()) {
+            try {
+                list.add(context.deserialize(item, valueType));
+            } catch (JsonParseException e) {
+                Log.w(TAG, "Ignoring invalid object from list", e);
+            }
+        }
+        return list;
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
@@ -137,16 +137,6 @@ public class Account extends BaseModel{
 	@Override
 	public void postprocess() throws ObjectValidationException{
 		super.postprocess();
-		if(fields!=null){
-			for(AccountField f:fields)
-				f.postprocess();
-		}
-		if(emojis!=null){
-			for(Emoji e:emojis)
-				e.postprocess();
-		}
-		if(moved!=null)
-			moved.postprocess();
 		if(TextUtils.isEmpty(displayName))
 			displayName=username;
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/BaseModel.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/BaseModel.java
@@ -1,14 +1,16 @@
 package org.joinmastodon.android.model;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+
 import org.joinmastodon.android.api.AllFieldsAreRequired;
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
+import org.parceler.OnUnwrap;
+import org.parceler.ParcelerRuntimeException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-
-import androidx.annotation.CallSuper;
-import androidx.annotation.NonNull;
 
 public abstract class BaseModel implements Cloneable{
 	@CallSuper
@@ -23,6 +25,16 @@ public abstract class BaseModel implements Cloneable{
 				}
 			}
 		}catch(IllegalAccessException ignore){}
+	}
+
+	// Makes sure to call postprocess() for BaseModel objects deserialized via Parceler
+	@OnUnwrap
+	protected void parcelerPostprocess() {
+		try {
+			postprocess();
+		} catch (ObjectValidationException e) {
+			throw new ParcelerRuntimeException("Could not parse Parcel", e);
+		}
 	}
 
 	@NonNull

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Filter.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Filter.java
@@ -1,6 +1,5 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.parceler.Parcel;
 
@@ -26,15 +25,6 @@ public class Filter extends BaseModel{
 	public List<FilterKeyword> keywords=new ArrayList<>();
 
 	public List<FilterStatus> statuses=new ArrayList<>();
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		for(FilterKeyword keyword:keywords)
-			keyword.postprocess();
-		for(FilterStatus status:statuses)
-			status.postprocess();
-	}
 
 	public boolean isActive(){
 		return expiresAt==null || expiresAt.isAfter(Instant.now());

--- a/mastodon/src/main/java/org/joinmastodon/android/model/FilterResult.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/FilterResult.java
@@ -1,6 +1,5 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.parceler.Parcel;
 
@@ -12,10 +11,4 @@ public class FilterResult extends BaseModel{
 	public Filter filter;
 
 	public List<String> keywordMatches;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		filter.postprocess();
-	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/FollowSuggestion.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/FollowSuggestion.java
@@ -1,16 +1,9 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 
 public class FollowSuggestion extends BaseModel{
 	@RequiredField
 	public Account account;
 //	public String source;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		account.postprocess();
-	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
@@ -85,8 +85,6 @@ public class Instance extends BaseModel{
 	@Override
 	public void postprocess() throws ObjectValidationException{
 		super.postprocess();
-		if(contactAccount!=null)
-			contactAccount.postprocess();
 		if(rules==null)
 			rules=Collections.emptyList();
 		if(shortDescription==null)

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Notification.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Notification.java
@@ -2,7 +2,6 @@ package org.joinmastodon.android.model;
 
 import com.google.gson.annotations.SerializedName;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.parceler.Parcel;
 
@@ -20,14 +19,6 @@ public class Notification extends BaseModel implements DisplayItemsParent{
 	public Account account;
 
 	public Status status;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		account.postprocess();
-		if(status!=null)
-			status.postprocess();
-	}
 
 	@Override
 	public String getID(){

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Poll.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Poll.java
@@ -1,6 +1,5 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.parceler.Parcel;
 
@@ -26,13 +25,6 @@ public class Poll extends BaseModel{
 	public List<Emoji> emojis;
 
 	public transient ArrayList<Option> selectedOptions;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		for(Emoji e:emojis)
-			e.postprocess();
-	}
 
 	@Override
 	public String toString(){

--- a/mastodon/src/main/java/org/joinmastodon/android/model/SearchResult.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/SearchResult.java
@@ -2,7 +2,6 @@ package org.joinmastodon.android.model;
 
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
-import org.joinmastodon.android.model.viewmodel.AccountViewModel;
 
 public class SearchResult extends BaseModel implements DisplayItemsParent{
 	public Account account;
@@ -41,12 +40,6 @@ public class SearchResult extends BaseModel implements DisplayItemsParent{
 	@Override
 	public void postprocess() throws ObjectValidationException{
 		super.postprocess();
-		if(account!=null)
-			account.postprocess();
-		if(hashtag!=null)
-			hashtag.postprocess();
-		if(status!=null)
-			status.postprocess();
 		generateID();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/SearchResults.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/SearchResults.java
@@ -1,28 +1,9 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
-
 import java.util.List;
 
 public class SearchResults extends BaseModel{
 	public List<Account> accounts;
 	public List<Status> statuses;
 	public List<Hashtag> hashtags;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		if(accounts!=null){
-			for(Account acc:accounts)
-				acc.postprocess();
-		}
-		if(statuses!=null){
-			for(Status s:statuses)
-				s.postprocess();
-		}
-		if(hashtags!=null){
-			for(Hashtag t:hashtags)
-				t.postprocess();
-		}
-	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Source.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Source.java
@@ -1,6 +1,5 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.parceler.Parcel;
 
@@ -37,13 +36,6 @@ public class Source extends BaseModel{
 	 * The number of pending follow requests.
 	 */
 	public int followRequestCount;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		for(AccountField f:fields)
-			f.postprocess();
-	}
 
 	@Override
 	public String toString(){

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
@@ -1,5 +1,7 @@
 package org.joinmastodon.android.model;
 
+import androidx.annotation.NonNull;
+
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
 import org.joinmastodon.android.events.StatusCountersUpdatedEvent;
@@ -8,8 +10,6 @@ import org.parceler.Parcel;
 
 import java.time.Instant;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 @Parcel
 public class Status extends BaseModel implements DisplayItemsParent{
@@ -67,28 +67,6 @@ public class Status extends BaseModel implements DisplayItemsParent{
 	@Override
 	public void postprocess() throws ObjectValidationException{
 		super.postprocess();
-		if(application!=null)
-			application.postprocess();
-		for(Mention m:mentions)
-			m.postprocess();
-		for(Hashtag t:tags)
-			t.postprocess();
-		for(Emoji e:emojis)
-			e.postprocess();
-		for(Attachment a:mediaAttachments)
-			a.postprocess();
-		account.postprocess();
-		if(poll!=null)
-			poll.postprocess();
-		if(card!=null)
-			card.postprocess();
-		if(reblog!=null)
-			reblog.postprocess();
-		if(filtered!=null){
-			for(FilterResult fr:filtered)
-				fr.postprocess();
-		}
-
 		spoilerRevealed=!sensitive;
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/StatusContext.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/StatusContext.java
@@ -1,7 +1,6 @@
 package org.joinmastodon.android.model;
 
 import org.joinmastodon.android.api.AllFieldsAreRequired;
-import org.joinmastodon.android.api.ObjectValidationException;
 
 import java.util.List;
 
@@ -9,13 +8,4 @@ import java.util.List;
 public class StatusContext extends BaseModel{
 	public List<Status> ancestors;
 	public List<Status> descendants;
-
-	@Override
-	public void postprocess() throws ObjectValidationException{
-		super.postprocess();
-		for(Status s:ancestors)
-			s.postprocess();
-		for(Status s:descendants)
-			s.postprocess();
-	}
 }


### PR DESCRIPTION
When working on fix #677, I noticed that `LegacyFilter` wasn't working as I expected. The reason was because `LegacyFilter.context` wasn't populated, although `LegacyFilter._context` was.

The reason was that because after the filters are retrieved from the server, they're persisted locally and later on loaded via GSON, and the GSON deserialization doesn't call `BaseModel.postprocess()`, so this (and a lot of other models, probably) weren't getting validated and correctly populated.

I made sure that `BaseModel.postprocess()` is getting called for every deserialized `BaseModel` by:
- Parceler:  added an `@OnUnwrap` method to `BaseModel` that calls `postprocess()`
- GSON:
  - Created `BaseModelTypeAdapterFactory` that calls `postprocess()`
  - Created `OptionalItemListDeserializer` to allow for lists of `BaseModel` to be deserialized by ignoring items that fail validation. Used by `GetNotifications`

This approach makes it unnecessary to call `BaseModel.postprocess()` throughout the code and also to remove code in a `BaseModel` that calls `postprocess()` recursively on its fields.

# !!! WARNING !!!

Since locally stored `BaseModel` instances did not have their `postprocess()` called, it is theoretically possible that invalid `BaseModel` instances are currently being saved on users' devices, and merging this PR would cause the app to crash for those users when it tries to load them.

But since those instances are basically invalid by definition, I don't find it much of a risk, and probably better to start crashing so we could fix those problems.

## How I tested

I ran this code snipped and debugged to see the correct methods are called and it behaves as expected:
```java
// Parceler: simple
{
	AccountField accountField = new AccountField();
	accountField.name = "name";
	accountField.value = "value";
	Parcel parcel = Parcel.obtain();
	parcel.writeParcelable(Parcels.wrap(accountField), 0);
	parcel.setDataPosition(0);
	AccountField anotherField = Parcels.unwrap(parcel.readParcelable(getClassLoader()));
	System.out.println(anotherField);
}

// Parceler: nested
{
	Filter filter = new Filter();
	filter.id = "id";
	filter.title = "title";
	filter.context = EnumSet.of(FilterContext.HOME);

	FilterResult filterResult = new FilterResult();
	filterResult.filter = filter;
	filterResult.keywordMatches=List.of("1", "2", "3");

	Parcel parcel = Parcel.obtain();
	parcel.writeParcelable(Parcels.wrap(filterResult), 0);
	parcel.setDataPosition(0);
	FilterResult anotherResult = Parcels.unwrap(parcel.readParcelable(getClassLoader()));
	System.out.println(anotherResult);
}

// GSON: optional items
{
	AccountField accountField = new AccountField();
	accountField.name = "name1";
	accountField.value = "value1";
	AccountField invalidField = new AccountField();
	invalidField.name = "name2";
	AccountField anotherField = new AccountField();
	anotherField.name = "name3";
	anotherField.value = "value3";

	String json = MastodonAPIController.gsonOptionalItemList.toJson(List.of(accountField,invalidField,anotherField));
	Object anotherFields=MastodonAPIController.gsonOptionalItemList.fromJson(json, new TypeToken<List<AccountField>>(){}.getType());
	System.out.println(anotherFields);
}
```