### PR TITLE
Add a setting for "Load missing posts behavior"

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -3,11 +3,14 @@ package org.joinmastodon.android;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.StringRes;
+
 public class GlobalUserPreferences{
 	public static boolean playGifs;
 	public static boolean useCustomTabs;
 	public static boolean altTextReminders, confirmUnfollow, confirmBoost, confirmDeletePost;
 	public static ThemePreference theme;
+	public static LoadMissingPostsPreference loadMissingPosts;
 
 	private static SharedPreferences getPrefs(){
 		return MastodonApp.context.getSharedPreferences("global", Context.MODE_PRIVATE);
@@ -22,6 +25,7 @@ public class GlobalUserPreferences{
 		confirmBoost=prefs.getBoolean("confirmBoost", false);
 		confirmDeletePost=prefs.getBoolean("confirmDeletePost", true);
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
+		loadMissingPosts=LoadMissingPostsPreference.values()[prefs.getInt("loadMissingItems", 0)];
 	}
 
 	public static void save(){
@@ -33,6 +37,7 @@ public class GlobalUserPreferences{
 				.putBoolean("confirmUnfollow", confirmUnfollow)
 				.putBoolean("confirmBoost", confirmBoost)
 				.putBoolean("confirmDeletePost", confirmDeletePost)
+				.putInt("loadMissingItems", loadMissingPosts.ordinal())
 				.apply();
 	}
 
@@ -40,5 +45,17 @@ public class GlobalUserPreferences{
 		AUTO,
 		LIGHT,
 		DARK
+	}
+
+	public enum LoadMissingPostsPreference{
+		NEWEST_FIRST(R.string.load_missing_posts_newest_first), // Downwards, default
+		OLDEST_FIRST(R.string.load_missing_posts_oldest_first); // Upwards
+
+		@StringRes
+		public int labelRes;
+
+		LoadMissingPostsPreference(@StringRes int labelRes){
+			this.labelRes=labelRes;
+		}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
@@ -14,9 +14,10 @@ import org.joinmastodon.android.ui.viewcontrollers.ComposeLanguageAlertViewContr
 
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 public class SettingsBehaviorFragment extends BaseSettingsFragment<Void>{
-	private ListItem<Void> languageItem;
+	private ListItem<Void> languageItem, loadMissingPostsItem;
 	private CheckableListItem<Void> altTextItem, playGifsItem, customTabsItem, confirmUnfollowItem, confirmBoostItem, confirmDeleteItem;
 	private Locale postLanguage;
 	private ComposeLanguageAlertViewController.SelectedOption newPostLanguage;
@@ -33,6 +34,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void>{
 
 		onDataLoaded(List.of(
 				languageItem=new ListItem<>(getString(R.string.default_post_language), postLanguage!=null ? postLanguage.getDisplayName(Locale.getDefault()) : null, R.drawable.ic_language_24px, this::onDefaultLanguageClick),
+				loadMissingPostsItem=new ListItem<>(R.string.settings_load_missing_posts, GlobalUserPreferences.loadMissingPosts.labelRes, R.drawable.ic_load_missing_posts_24, this::onLoadMissingPostsClick),
 				altTextItem=new CheckableListItem<>(R.string.settings_alt_text_reminders, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.altTextReminders, R.drawable.ic_alt_24px, ()->toggleCheckableItem(altTextItem)),
 				playGifsItem=new CheckableListItem<>(R.string.settings_gif, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.playGifs, R.drawable.ic_animation_24px, ()->toggleCheckableItem(playGifsItem)),
 				customTabsItem=new CheckableListItem<>(R.string.settings_custom_tabs, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.useCustomTabs, R.drawable.ic_open_in_browser_24px, ()->toggleCheckableItem(customTabsItem)),
@@ -56,6 +58,27 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void>{
 						newPostLanguage=opt;
 						languageItem.subtitle=newPostLanguage.locale.getDisplayLanguage(Locale.getDefault());
 						rebindItem(languageItem);
+					}
+				})
+				.setNegativeButton(R.string.cancel, null)
+				.show();
+	}
+
+	private void onLoadMissingPostsClick(){
+		GlobalUserPreferences.LoadMissingPostsPreference[] values=GlobalUserPreferences.LoadMissingPostsPreference.values();
+		int selected=GlobalUserPreferences.loadMissingPosts.ordinal();
+		int[] newSelected={selected};
+		new M3AlertDialogBuilder(getActivity())
+				.setTitle(R.string.settings_load_missing_posts)
+				.setSingleChoiceItems(Stream.of(values).map(pref->getString(pref.labelRes)).toArray(String[]::new),
+						selected, (dlg, item)->newSelected[0]=item)
+				.setPositiveButton(R.string.ok, (dlg, item)->{
+					GlobalUserPreferences.LoadMissingPostsPreference pref=values[newSelected[0]];
+					if(pref!=GlobalUserPreferences.loadMissingPosts){
+						GlobalUserPreferences.loadMissingPosts=pref;
+						GlobalUserPreferences.save();
+						loadMissingPostsItem.subtitleRes=pref.labelRes;
+						rebindItem(loadMissingPostsItem);
 					}
 				})
 				.setNegativeButton(R.string.cancel, null)

--- a/mastodon/src/main/res/drawable/ic_load_missing_posts_24.xml
+++ b/mastodon/src/main/res/drawable/ic_load_missing_posts_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M8,19h3v4h2v-4h3l-4,-4 -4,4zM16,5h-3L13,1h-2v4L8,5l4,4 4,-4zM4,11v2h16v-2L4,11z"/>
+</vector>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -223,6 +223,9 @@
 	<string name="settings_privacy_policy">Privacy policy</string>
 	<string name="settings_clear_cache">Clear media cache</string>
 	<string name="settings_app_version">Mastodon for Android v%1$s (%2$d)</string>
+	<string name="settings_load_missing_posts">Load missing posts behavior</string>
+	<string name="load_missing_posts_newest_first">Newest first (downwards)</string>
+	<string name="load_missing_posts_oldest_first">Oldest first (upwards)</string>
 	<string name="media_cache_cleared">Media cache cleared</string>
 	<string name="confirm_log_out">Log out of %s?</string>
 	<string name="sensitive_content_explain">The author marked this media as sensitive.</string>


### PR DESCRIPTION
It allows the user to, if they prefer, loading missing posts from the oldest post onwards (upwards).

I understand that new features should be suggested on the iOS app repo, vetted, planned, coordinated with a UX designer, and then implemented. But I was poking around the code, wanted to test how hard would it be to give it a try myself, and I think I came up with a good solution.

No new design/layout was added as I able to reuse the existing Settings framework. That being said, I made some UX decisions/assumptions:

- [ ] No visual indication of current setting in the "Load missing posts" button. Putting arrows up/down would be an alternative
- [ ] Placement of the setting: Settings -> Behavior
- [ ] Setting icon: [`Vertical Align Center`](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:vertical_align_center:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=align) from Material Icons <img src="https://github.com/mastodon/mastodon-android/assets/1063155/aaa6ce29-b9ae-4fcb-93ee-cbedf69ea093" height=24/>
- [ ] Setting name: "Load missing posts behavior"
- [ ] Value name: "Newest first (downwards)", the default and current behavior
- [ ] Value name: "Oldest first (upwards)", the new behavior

One can easily (and repeatedly) test the feature by using the mock data from this branch: https://github.com/tinsukE/mastodon-android/pull/1

## Boost this change so it gets more attention!

https://mas.to/@tinsuke/110991335369359509

## Settings

<img src="https://github.com/mastodon/mastodon-android/assets/1063155/a05c88e7-a48c-4f7b-870d-81e9cba9a6b7" width=270/>    <img src="https://github.com/mastodon/mastodon-android/assets/1063155/b1977504-4499-4400-acde-cbda726f3d15" width=270/>

## Test builds

- Debug build with the feature (you'll have to uninstall your currently installed version to install this one): [mastodon-debug.apk.zip](https://github.com/mastodon/mastodon-android/files/12500625/mastodon-debug.apk.zip)
- Debug build with mock data (so you can reproduce the TL on the GIF below over and over): [mastodon-debug-mock.apk.zip](https://github.com/mastodon/mastodon-android/files/12500616/mastodon-debug-mock.apk.zip)

## Downwards (current, default) x Upwards (brand new)

![load more](https://github.com/mastodon/mastodon-android/assets/1063155/f3d3399c-7735-4d8c-b0b2-392599e6a8e4)

Fixes #154