### PR TITLE
fix(compose): fix photoPicker not popping up when there is less than 2 spaces available for media

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -839,7 +839,8 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		boolean usePhotoPicker=UiUtils.isPhotoPickerAvailable();
 		if(usePhotoPicker){
 			intent=new Intent(MediaStore.ACTION_PICK_IMAGES);
-			intent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, mediaViewController.getMaxAttachments()-mediaViewController.getMediaAttachmentsCount());
+			if(mediaViewController.getMaxAttachments()-mediaViewController.getMediaAttachmentsCount()>1)
+				intent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, mediaViewController.getMaxAttachments()-mediaViewController.getMediaAttachmentsCount());
 		}else{
 			intent=new Intent(Intent.ACTION_GET_CONTENT);
 			intent.addCategory(Intent.CATEGORY_OPENABLE);


### PR DESCRIPTION
This fixes an issue where if the amount of images that are allowed to be selected are less than 2 and the EXTRA_PICK_IMAGES_MAX property is set as 1 the image picker wouldn't popup. 