### PR TITLE
fix: UI/UX- Hide compose FAB when in About tab / editing #183

### DIFF
--- a/mastodon/src/main/res/layout/fragment_profile.xml
+++ b/mastodon/src/main/res/layout/fragment_profile.xml
@@ -329,6 +329,7 @@
 			android:layout_gravity="end|bottom"
 			android:layout_marginEnd="16dp"
 			android:layout_marginBottom="16dp"
+			android:visibility="gone"
 			android:background="@drawable/bg_fab"
 			android:contentDescription="@string/new_post"
 			android:scaleType="center"


### PR DESCRIPTION
I fixed #183

before the change
![Screenshot_1](https://github.com/mastodon/mastodon-android/assets/135522803/6091ede2-4d54-4b4b-a740-fd1f7c30819c)

after the change 
![Screenshot_2](https://github.com/mastodon/mastodon-android/assets/135522803/91683176-7aa9-4a1e-88b9-509c1cf63962)
