### PR TITLE
fix: UI/UX- Hide compose FAB when in About tab / editing #183

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -840,7 +840,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		username.setVisibility(View.GONE);
 		bio.setVisibility(View.GONE);
 		countersLayout.setVisibility(View.GONE);
-
+		fab.setVisibility(View.GONE);
 		nameEditWrap.setVisibility(View.VISIBLE);
 		nameEdit.setText(account.displayName);
 
@@ -888,6 +888,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		name.setVisibility(View.VISIBLE);
 		username.setVisibility(View.VISIBLE);
 		bio.setVisibility(View.VISIBLE);
+		fab.setVisibility(View.VISIBLE);
 		countersLayout.setVisibility(View.VISIBLE);
 		refreshLayout.setEnabled(true);
 


### PR DESCRIPTION
this PR fix #183

Now the "source" fails fab icon will not hide

https://github.com/mastodon/mastodon-android/assets/135522803/f154b556-bc0c-4c12-8afd-72ba47ec69f8

