### PR TITLE
Remove garbage alt text from images attached via Gboard

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -1012,8 +1012,26 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		return new String[]{"image/jpeg", "image/gif", "image/png", "video/mp4"};
 	}
 
+	private String sanitizeMediaDescription(String description){
+		if(description == null){
+			return null;
+		}
+
+		// The Gboard android keyboard attaches this text whenever the user
+		// pastes something from the keyboard's suggestion bar.
+		// Due to different end user locales, the exact text may vary, but at
+		// least in version 13.4.08, all of the translations contained the
+		// string "Gboard".
+		if (description.contains("Gboard")){
+			return null;
+		}
+
+		return description;
+	}
+
 	@Override
 	public boolean onAddMediaAttachmentFromEditText(Uri uri, String description){
+		description = sanitizeMediaDescription(description);
 		return mediaViewController.addMediaAttachment(uri, description);
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeMediaViewController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeMediaViewController.java
@@ -126,25 +126,7 @@ public class ComposeMediaViewController{
 		}
 	}
 
-	private String sanitizeMediaDescription(String description){
-		if(description == null){
-			return null;
-		}
-
-		// The Gboard android keyboard attaches this text whenever the user
-		// pastes something from the keyboard's suggestion bar.
-		// Due to different end user locales, the exact text may vary, but at
-		// least in version 13.4.08, all of the translations contained the
-		// string "Gboard".
-		if (description.contains("Gboard")){
-			return null;
-		}
-
-		return description;
-	}
-	
 	public boolean addMediaAttachment(Uri uri, String description){
-		description = sanitizeMediaDescription(description);
 		if(getMediaAttachmentsCount()==MAX_ATTACHMENTS){
 			showMediaAttachmentError(fragment.getResources().getQuantityString(R.plurals.cant_add_more_than_x_attachments, MAX_ATTACHMENTS, MAX_ATTACHMENTS));
 			return false;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeMediaViewController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeMediaViewController.java
@@ -125,8 +125,26 @@ public class ComposeMediaViewController{
 			updateMediaAttachmentsLayout();
 		}
 	}
+
+	private String sanitizeMediaDescription(String description){
+		if(description == null){
+			return null;
+		}
+
+		// The Gboard android keyboard attaches this text whenever the user
+		// pastes something from the keyboard's suggestion bar.
+		// Due to different end user locales, the exact text may vary, but at
+		// least in version 13.4.08, all of the translations contained the
+		// string "Gboard".
+		if (description.contains("Gboard")){
+			return null;
+		}
+
+		return description;
+	}
 	
 	public boolean addMediaAttachment(Uri uri, String description){
+		description = sanitizeMediaDescription(description);
 		if(getMediaAttachmentsCount()==MAX_ATTACHMENTS){
 			showMediaAttachmentError(fragment.getResources().getQuantityString(R.plurals.cant_add_more_than_x_attachments, MAX_ATTACHMENTS, MAX_ATTACHMENTS));
 			return false;


### PR DESCRIPTION
See also: https://github.com/tuskyapp/Tusky/pull/4068

----

Steps to reproduce:

1. install Gboard
   (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)

2. open a direct link to any image in Firefox
3. long-press the image to get a "Copy Image" dialogue (and copy the
   image)
4. compose a new post in Mastodon for Android
5. Gboard will suggest to paste the image from clipboard
6. paste image, see that when opening alt text editor, it is filled out
   with this garbage string

Why is this bad? It's not when I just fix the alt text. But it breaks
every mechanism that is supposed to remind me of adding alt text.

It's hard to argue that this is within scope of this app but I
also don't see it getting fixed in Gboard, so here we go.
