### PR TITLE
fix: edit history crash

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/statuses/GetStatusEditHistory.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/statuses/GetStatusEditHistory.java
@@ -26,6 +26,11 @@ public class GetStatusEditHistory extends MastodonAPIRequest<List<Status>>{
 			s.visibility=StatusPrivacy.PUBLIC;
 			s.mentions=Collections.emptyList();
 			s.tags=Collections.emptyList();
+			if(s.poll!=null){
+				s.poll.id="fakeID"+i;
+				s.poll.emojis=Collections.emptyList();
+				s.poll.ownVotes=Collections.emptyList();
+			}
 			i++;
 		}
 		super.validateAndPostprocessResponse(respObj, httpResponse);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/InsetStatusItemDecoration.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/InsetStatusItemDecoration.java
@@ -93,7 +93,7 @@ public class InsetStatusItemDecoration extends RecyclerView.ItemDecoration{
 					outRect.left=outRect.right=V.dp(8);
 				if(!bottomSiblingInset)
 					outRect.bottom=V.dp(16);
-				if(!topSiblingInset && displayItems.get(pos-1) instanceof NotificationHeaderStatusDisplayItem)
+				if(!topSiblingInset && pos > 1 && displayItems.get(pos-1) instanceof NotificationHeaderStatusDisplayItem)
 					outRect.top=V.dp(-8);
 			}
 		}


### PR DESCRIPTION
Fixes a problem where the application would crash when opening and closing the content warning of a post in the edit history screen, caused by trying to access index `-2` of the array.

Also fixes an issue where the edit history could not be displayed if it contained a poll, due to the API response not providing required fields. I can move this commit to a separate pull request if you prefer. There is also an issue where the poll is still clickable, but I'm not sure what the best way to fix this is.

![Poll screen failed to load](https://github.com/mastodon/mastodon-android/assets/63370021/5bdebf3c-f99d-4e60-a1b0-dc9763fdf668)
