### PR TITLE
fix: disable group divider on EMUI

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -136,7 +136,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 
 			optionsMenu=new PopupMenu(activity, more);
 			optionsMenu.inflate(R.menu.post);
-			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P)
+			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
 				optionsMenu.getMenu().setGroupDividerEnabled(true);
 			optionsMenu.setOnMenuItemClickListener(menuItem->{
 				Account account=item.user;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -685,6 +685,10 @@ public class UiUtils{
 		return !TextUtils.isEmpty(getSystemProperty("ro.miui.ui.version.code"));
 	}
 
+	public static boolean isEMUI() {
+		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.emui"));
+	}
+
 	public static int alphaBlendColors(int color1, int color2, float alpha){
 		float alpha0=1f-alpha;
 		int r=Math.round(((color1 >> 16) & 0xFF)*alpha0+((color2 >> 16) & 0xFF)*alpha);


### PR DESCRIPTION
Fixes an issue, where due to the group divider being enabled, the menu item is not visible.

![Menu with invisible option](https://github.com/mastodon/mastodon-android/assets/63370021/11194075-52b8-49d0-92a1-2fd24e16f88e)
