### PR TITLE
Allow translation of attachments, spoilers and polls

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -616,6 +616,11 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 			imgLoader.bindViewHolder((ImageLoaderRecyclerAdapter) list.getAdapter(), text, text.getAbsoluteAdapterPosition());
 		}
 
+		SpoilerStatusDisplayItem.Holder spoiler=findHolderOfType(itemID, SpoilerStatusDisplayItem.Holder.class);
+		if(spoiler!=null){
+			spoiler.rebind();
+		}
+
 		MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
 		if (media!=null) {
 			media.rebind();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -586,6 +586,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 										return;
 									status.translation=result;
 									status.translationState=Status.TranslationState.SHOWN;
+									MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
+									if (media!=null) {
+										media.rebind();
+									}
 									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
 									if(text!=null){
 										text.updateTranslation(true);
@@ -618,7 +622,14 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 			text.updateTranslation(true);
 			imgLoader.bindViewHolder((ImageLoaderRecyclerAdapter) list.getAdapter(), text, text.getAbsoluteAdapterPosition());
 		}
+
+		MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
+		if (media!=null) {
+			media.rebind();
+		}
 	}
+
+	private void updateTranslation() {}
 
 	public void rebuildAllDisplayItems(){
 		displayItems.clear();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -357,7 +357,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		List<StatusDisplayItem> pollItems=displayItems.subList(firstOptionIndex, footerIndex+1);
 		int prevSize=pollItems.size();
 		pollItems.clear();
-		StatusDisplayItem.buildPollItems(itemID, this, poll, pollItems);
+		StatusDisplayItem.buildPollItems(itemID, this, poll, pollItems, status);
 		if(prevSize!=pollItems.size()){
 			adapter.notifyItemRangeRemoved(firstOptionIndex, prevSize);
 			adapter.notifyItemRangeInserted(firstOptionIndex, pollItems.size());
@@ -586,15 +586,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 										return;
 									status.translation=result;
 									status.translationState=Status.TranslationState.SHOWN;
-									MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
-									if (media!=null) {
-										media.rebind();
-									}
-									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
-									if(text!=null){
-										text.updateTranslation(true);
-										imgLoader.bindViewHolder((ImageLoaderRecyclerAdapter) list.getAdapter(), text, text.getAbsoluteAdapterPosition());
-									}
+									updateTranslation(itemID);
 								}
 
 								@Override
@@ -602,10 +594,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 									if(getActivity()==null)
 										return;
 									status.translationState=Status.TranslationState.HIDDEN;
-									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
-									if(text!=null){
-										text.updateTranslation(true);
-									}
+									updateTranslation(itemID);
 									new M3AlertDialogBuilder(getActivity())
 											.setTitle(R.string.error)
 											.setMessage(R.string.translation_failed)
@@ -617,6 +606,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 				}
 			}
 		}
+		updateTranslation(itemID);
+	}
+
+	private void updateTranslation(String itemID) {
 		TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
 		if(text!=null){
 			text.updateTranslation(true);
@@ -627,9 +620,13 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		if (media!=null) {
 			media.rebind();
 		}
-	}
 
-	private void updateTranslation() {}
+		for(int i=0;i<list.getChildCount();i++){
+			if(list.getChildViewHolder(list.getChildAt(i)) instanceof PollOptionStatusDisplayItem.Holder item){
+				item.rebind();
+			}
+		}
+	}
 
 	public void rebuildAllDisplayItems(){
 		displayItems.clear();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -357,7 +357,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		List<StatusDisplayItem> pollItems=displayItems.subList(firstOptionIndex, footerIndex+1);
 		int prevSize=pollItems.size();
 		pollItems.clear();
-		StatusDisplayItem.buildPollItems(itemID, this, poll, pollItems, status);
+		StatusDisplayItem.buildPollItems(itemID, this, poll, status, pollItems);
 		if(prevSize!=pollItems.size()){
 			adapter.notifyItemRangeRemoved(firstOptionIndex, prevSize);
 			adapter.notifyItemRangeInserted(firstOptionIndex, pollItems.size());

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -10,6 +10,7 @@ public class Translation extends BaseModel{
 	public String detectedSourceLanguage;
 	@RequiredField
 	public String provider;
+	public String spoilerText;
 	public MediaAttachment[] mediaAttachments;
 	public PollTranslation poll;
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -7,4 +7,10 @@ public class Translation extends BaseModel{
 	public String content;
 	public String detectedSourceLanguage;
 	public String provider;
+	public MediaAttachment[] mediaAttachments;
+
+	public static class MediaAttachment {
+		public String id;
+		public String description;
+	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -11,9 +11,19 @@ public class Translation extends BaseModel{
 	@RequiredField
 	public String provider;
 	public MediaAttachment[] mediaAttachments;
+	public PollTranslation poll;
 
 	public static class MediaAttachment {
 		public String id;
 		public String description;
+	}
+
+	public static class PollTranslation {
+		public String id;
+		public PollOption[] options;
+	}
+
+	public static class PollOption {
+		public String title;
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -1,11 +1,14 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.AllFieldsAreRequired;
 
-@AllFieldsAreRequired
+import org.joinmastodon.android.api.RequiredField;
+
 public class Translation extends BaseModel{
+	@RequiredField
 	public String content;
+	@RequiredField
 	public String detectedSourceLanguage;
+	@RequiredField
 	public String provider;
 	public MediaAttachment[] mediaAttachments;
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Poll;
+import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.text.HtmlParser;
 import org.joinmastodon.android.ui.utils.CustomEmojiHelper;
@@ -22,6 +23,7 @@ import me.grishka.appkit.imageloader.requests.ImageLoaderRequest;
 
 public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 	private CharSequence text;
+	private CharSequence translatedText;
 	public final Poll.Option option;
 	private CustomEmojiHelper emojiHelper=new CustomEmojiHelper();
 	private boolean showResults;
@@ -29,12 +31,15 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 	private boolean isMostVoted;
 	private final int optionIndex;
 	public final Poll poll;
+	public final Status status;
 
-	public PollOptionStatusDisplayItem(String parentID, Poll poll, int optionIndex, BaseStatusListFragment parentFragment){
+
+	public PollOptionStatusDisplayItem(String parentID, Poll poll, int optionIndex, BaseStatusListFragment parentFragment, Status status){
 		super(parentID, parentFragment);
 		this.optionIndex=optionIndex;
 		option=poll.options.get(optionIndex);
 		this.poll=poll;
+		this.status=status;
 		text=HtmlParser.parseCustomEmoji(option.title, poll.emojis);
 		emojiHelper.setText(text);
 		showResults=poll.isExpired() || poll.voted;
@@ -83,7 +88,14 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 
 		@Override
 		public void onBind(PollOptionStatusDisplayItem item){
-			text.setText(item.text);
+			if (item.status.translation != null && item.status.translationState == Status.TranslationState.SHOWN) {
+				if(item.translatedText==null){
+					item.translatedText=item.status.translation.poll.options[item.optionIndex].title;
+				}
+				text.setText(item.translatedText);
+			} else {
+				text.setText(item.text);
+			}
 			percent.setVisibility(item.showResults ? View.VISIBLE : View.GONE);
 			itemView.setClickable(!item.showResults);
 			if(item.showResults){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/SpoilerStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/SpoilerStatusDisplayItem.java
@@ -26,6 +26,7 @@ public class SpoilerStatusDisplayItem extends StatusDisplayItem{
 	public final Status status;
 	public final ArrayList<StatusDisplayItem> contentItems=new ArrayList<>();
 	private final CharSequence parsedTitle;
+	private CharSequence translatedTitle;
 	private final CustomEmojiHelper emojiHelper;
 	private final Type type;
 
@@ -85,7 +86,14 @@ public class SpoilerStatusDisplayItem extends StatusDisplayItem{
 
 		@Override
 		public void onBind(SpoilerStatusDisplayItem item){
-			title.setText(item.parsedTitle);
+			if(item.status.translationState==Status.TranslationState.SHOWN){
+				if(item.translatedTitle==null){
+					item.translatedTitle=item.status.translation.spoilerText;
+				}
+				title.setText(item.translatedTitle);
+			}else{
+				title.setText(item.parsedTitle);
+			}
 			action.setText(item.status.spoilerRevealed ? R.string.spoiler_hide : R.string.spoiler_show);
 		}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -162,7 +162,7 @@ public abstract class StatusDisplayItem{
 			}
 		}
 		if(statusForContent.poll!=null){
-			buildPollItems(parentID, fragment, statusForContent.poll, contentItems);
+			buildPollItems(parentID, fragment, statusForContent.poll, status, contentItems);
 		}
 		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && TextUtils.isEmpty(statusForContent.spoilerText)){
 			contentItems.add(new LinkCardStatusDisplayItem(parentID, fragment, statusForContent));
@@ -192,10 +192,10 @@ public abstract class StatusDisplayItem{
 		return items;
 	}
 
-	public static void buildPollItems(String parentID, BaseStatusListFragment fragment, Poll poll, List<StatusDisplayItem> items){
+	public static void buildPollItems(String parentID, BaseStatusListFragment fragment, Poll poll, Status status, List<StatusDisplayItem> items){
 		int i=0;
 		for(Poll.Option opt:poll.options){
-			items.add(new PollOptionStatusDisplayItem(parentID, poll, i, fragment));
+			items.add(new PollOptionStatusDisplayItem(parentID, poll, i, fragment, status));
 			i++;
 		}
 		items.add(new PollFooterStatusDisplayItem(parentID, fragment, poll));


### PR DESCRIPTION
Adds the ability to translate not only status text, but also media attachment descriptions (alt text) and poll options, a new feature introduced in [4.2.0](https://github.com/mastodon/mastodon/releases/tag/v4.2.0).


| Untranslated                                                                                                       	| Translated                                                                                                      	|
|--------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------	|
| ![Untranslated poll](https://github.com/mastodon/mastodon-android/assets/63370021/8b6f5af4-daeb-4e75-83e7-66907c6133ec) 	| ![Translated poll](https://github.com/mastodon/mastodon-android/assets/63370021/e21a7980-43cf-4d82-97c1-8d849acd1f68) 	|

This still has an issue where when translating the alt text, the images are temporarily replaced with images from the posts above. This is reset when the user scrolls. I'm not sure if this is a translation issue or an issue with reloading the media view and how to fix it.
Additionally, as the translation button is part of the TextStatusDisplayItem, it is only shown for posts containing translatable text.

Originally written for https://github.com/sk22/megalodon/pull/916.