### PR TITLE
Delete `id.xml` shared pref from the correct dir

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -181,7 +181,11 @@ public class AccountSessionManager{
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N){
 			MastodonApp.context.deleteSharedPreferences(id);
 		}else{
-			new File(MastodonApp.context.getDir("shared_prefs", Context.MODE_PRIVATE), id+".xml").delete();
+			String dataDir=MastodonApp.context.getApplicationInfo().dataDir;
+			if(dataDir!=null){
+				File prefsDir=new File(dataDir, "shared_prefs");
+				new File(prefsDir, id+".xml").delete();
+			}
 		}
 		sessions.remove(id);
 		if(lastActiveAccountID.equals(id)){


### PR DESCRIPTION
Fixes app failing to delete the `$id.xml` shared pref on Android M, because `getDir("shared_prefs"..)` for some reason returns `/data/.../app_shared_prefs/` dir, which is empty or non-existent.

To reproduce:
1. log into any account
2. log out
3. observe `shared_prefs/id.xml` pref still there