### PR TITLE
fix: NullPointerException crash while change post language twice

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeLanguageAlertViewController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeLanguageAlertViewController.java
@@ -97,7 +97,7 @@ public class ComposeLanguageAlertViewController{
 				int i=0;
 				boolean found=false;
 				for(SpecialLocaleInfo li:specialLocales){
-					if(li.locale.equals(previouslySelected.locale)){
+					if(null!=li.locale&&li.locale.equals(previouslySelected.locale)){
 						selectedLocale=li.locale;
 						selectedIndex=i;
 						found=true;


### PR DESCRIPTION
Closes https://github.com/mastodon/mastodon-android/issues/766


## crash reason

the `detected` added to `specialLocales` may have nullable `locale`(which should be initialized in `detectLanguage()` later)

https://github.com/mastodon/mastodon-android/blob/48f9aabaf7f0b329d5e04583ef2b817f0301dc6c/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeLanguageAlertViewController.java#L83-L89

and this will cause `NullPointerException` in line 100

https://github.com/mastodon/mastodon-android/blob/48f9aabaf7f0b329d5e04583ef2b817f0301dc6c/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposeLanguageAlertViewController.java#L99-L107

## solution

add nullable check