### PR TITLE
fix: disable group divider in ProfileFragment on EMUI

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -635,7 +635,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			menu.findItem(R.id.block_domain).setVisible(false);
 		menu.findItem(R.id.add_to_list).setVisible(relationship.following);
 
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P){
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI()){
 			menu.setGroupDividerEnabled(true);
 		}
 	}


### PR DESCRIPTION
Fixes a similar issue as https://github.com/mastodon/mastodon-android/pull/732, introduced in https://github.com/mastodon/mastodon-android/commit/eacfd2fa4f7e3df7ae008675a2e946d791f33e95.