### PR TITLE
fix: include account when opening FeaturedHashtags

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFeaturedFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFeaturedFragment.java
@@ -198,6 +198,7 @@ public class ProfileFeaturedFragment extends BaseStatusListFragment<SearchResult
 	private void showAllFeaturedHashtags(){
 		Bundle args=new Bundle();
 		args.putString("account", accountID);
+		args.putParcelable("profileAccount", Parcels.wrap(profileAccount));
 		ArrayList<Parcelable> tags=featuredTags.stream().map(Parcels::wrap).collect(Collectors.toCollection(ArrayList::new));
 		args.putParcelableArrayList("hashtags", tags);
 		Nav.go(getActivity(), FeaturedHashtagsListFragment.class, args);


### PR DESCRIPTION
Fixes a NullPointerExpecption caused by not passing the account from the `ProfileFeaturedFragment` to the `FeaturedHashtagsListFragment`.

Closes https://github.com/mastodon/mastodon-android/issues/803.