### PR TITLE
Display more user-friendly error messages

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/MastodonErrorResponse.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/MastodonErrorResponse.java
@@ -32,23 +32,35 @@ public class MastodonErrorResponse extends ErrorResponse{
 			this.messageResource=R.string.connection_timed_out;
 		}else if(exception instanceof JsonSyntaxException || exception instanceof JsonIOException || httpStatus>=500){
 			this.messageResource=R.string.server_error;
-		}else if(httpStatus == 404){
+		}else if(httpStatus==404){
 			this.messageResource=R.string.not_found;
 		}else{
-			this.messageResource=R.string.unknown_error;
+			this.messageResource=0;
 		}
 	}
 
 	@Override
 	public void bindErrorView(View view){
 		TextView text=view.findViewById(R.id.error_text);
-		text.setText(view.getContext().getString(messageResource, error));
+		String message;
+		if(messageResource>0){
+			message=view.getContext().getString(messageResource, error);
+		}else{
+			message=error;
+		}
+		text.setText(message);
 	}
 
 	@Override
 	public void showToast(Context context){
 		if(context==null)
 			return;
-		Toast.makeText(context, context.getString(messageResource, error), Toast.LENGTH_SHORT).show();
+		String message;
+		if(messageResource>0){
+			message=context.getString(messageResource, error);
+		}else{
+			message=error;
+		}
+		Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/api/MastodonErrorResponse.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/MastodonErrorResponse.java
@@ -5,7 +5,13 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
 import org.joinmastodon.android.R;
+
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 
 import me.grishka.appkit.api.ErrorResponse;
 
@@ -13,23 +19,36 @@ public class MastodonErrorResponse extends ErrorResponse{
 	public final String error;
 	public final int httpStatus;
 	public final Throwable underlyingException;
+	public final int messageResource;
 
 	public MastodonErrorResponse(String error, int httpStatus, Throwable exception){
 		this.error=error;
 		this.httpStatus=httpStatus;
 		this.underlyingException=exception;
+
+		if(exception instanceof UnknownHostException){
+			this.messageResource=R.string.could_not_reach_server;
+		}else if(exception instanceof SocketTimeoutException){
+			this.messageResource=R.string.connection_timed_out;
+		}else if(exception instanceof JsonSyntaxException || exception instanceof JsonIOException || httpStatus>=500){
+			this.messageResource=R.string.server_error;
+		}else if(httpStatus == 404){
+			this.messageResource=R.string.not_found;
+		}else{
+			this.messageResource=R.string.unknown_error;
+		}
 	}
 
 	@Override
 	public void bindErrorView(View view){
 		TextView text=view.findViewById(R.id.error_text);
-		text.setText(error);
+		text.setText(view.getContext().getString(messageResource, error));
 	}
 
 	@Override
 	public void showToast(Context context){
 		if(context==null)
 			return;
-		Toast.makeText(context, error, Toast.LENGTH_SHORT).show();
+		Toast.makeText(context, context.getString(messageResource, error), Toast.LENGTH_SHORT).show();
 	}
 }

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -755,9 +755,8 @@
 	<string name="view_favorites">View favorites</string>
 	<string name="undo_reblog">Undo boost</string>
 	<string name="undo_favorite">Undo favorite</string>
-	<string name="could_not_reach_server">Could not reach the server. Make sure you\'re connected to the internet and try again.</string>
-	<string name="connection_timed_out">Connection timed out. Make sure you\'re connected to the internet and try again.</string>
-	<string name="server_error">There may be a problem with your instance or your internet. Make sure you have access to the internet and try again.</string>
-	<string name="not_found">Not found. It probably doesn\'t exist anymore.</string>
-	<string name="unknown_error">Unknown error: %s</string>
+	<string name="could_not_reach_server">Couldn’t reach the server. Check your connection and try again?</string>
+	<string name="connection_timed_out">The request timed out. Check your connection and try again?</string>
+	<string name="server_error">Something went wrong talking with your server. It’s probably not your fault. Try again?</string>
+	<string name="not_found">It could’ve been deleted, or maybe it never existed at all.</string>
 </resources>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -755,4 +755,9 @@
 	<string name="view_favorites">View favorites</string>
 	<string name="undo_reblog">Undo boost</string>
 	<string name="undo_favorite">Undo favorite</string>
+	<string name="could_not_reach_server">Could not reach the server. Make sure you\'re connected to the internet and try again.</string>
+	<string name="connection_timed_out">Connection timed out. Make sure you\'re connected to the internet and try again.</string>
+	<string name="server_error">There may be a problem with your instance or your internet. Make sure you have access to the internet and try again.</string>
+	<string name="not_found">Not found. It probably doesn\'t exist anymore.</string>
+	<string name="unknown_error">Unknown error: %s</string>
 </resources>


### PR DESCRIPTION
Instead of displaying the Java exception, this change displays a more user-friendly message for some common network-related issues.

Fixes mastodon/mastodon-android#667

Please let me know if this is a good way to implement this or what would be the best way to do it, if not.
