### PR TITLE
Added network security config

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 		android:allowBackup="true"
 		android:label="@string/app_name"
 		android:supportsRtl="true"
+		android:networkSecurityConfig="@xml/network_security_config"
 		android:icon="@mipmap/ic_launcher"
 		android:theme="@style/Theme.Mastodon.AutoLightDark"
 		android:largeHeap="true">

--- a/mastodon/src/main/res/xml/network_security_config.xml
+++ b/mastodon/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+	<base-config>
+		<trust-anchors>
+
+			<certificates src="system" />
+			<certificates src="user" />
+		</trust-anchors>
+	</base-config>
+</network-security-config>


### PR DESCRIPTION
On older Android devices the root certificates don't get updated anymore. Because the commonly used Let's encrypt root certificate expired some time ago, older Android devices are not able to connect to the mastodon servers. But the user can add root certificates manually to the user certificate store in the Android settings.
**This pull request adds the user certificate store to the list of trust anchors in the mastodon app.**
With this small code change the users of older android devices can add the root certificate to the user certificate store and connect to the mastodon servers.
I tested it on an Asus P00A with Android 7 and would appreciate it if you decide to merge this pull request.

Kind Regards.