### PR TITLE
fix: disable GroupDivider on Honor's MagicOS

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -687,7 +687,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			notifications.setTitle(getString(relationship.notifying ? R.string.disable_new_post_notifications : R.string.enable_new_post_notifications, account.getDisplayUsername()));
 		}
 
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI()){
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic()){
 			menu.setGroupDividerEnabled(true);
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -140,7 +140,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 
 			optionsMenu=new PopupMenu(activity, more);
 			optionsMenu.inflate(R.menu.post);
-			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
+			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic())
 				optionsMenu.getMenu().setGroupDividerEnabled(true);
 			optionsMenu.setOnMenuItemClickListener(menuItem->{
 				Account account=item.user;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -809,6 +809,10 @@ public class UiUtils{
 		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.emui"));
 	}
 
+	public static boolean isMagic() {
+		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.magic"));
+	}
+
 	public static int alphaBlendColors(int color1, int color2, float alpha){
 		float alpha0=1f-alpha;
 		int r=Math.round(((color1 >> 16) & 0xFF)*alpha0+((color2 >> 16) & 0xFF)*alpha);


### PR DESCRIPTION
When enabled on [MagicOS](https://www.honor.com/global/magic-os/), GroupDividers are not displayed and causes other menu items to be invisible. Similar bug to
https://github.com/mastodon/mastodon-android/pull/732.