### PR TITLE
fix: Remove charset from application/json content type

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/JsonObjectRequestBody.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/JsonObjectRequestBody.java
@@ -20,7 +20,7 @@ public class JsonObjectRequestBody extends RequestBody{
 
 	@Override
 	public MediaType contentType(){
-		return MediaType.get("application/json;charset=utf-8");
+		return MediaType.get("application/json");
 	}
 
 	@Override


### PR DESCRIPTION
Per https://datatracker.ietf.org/doc/html/rfc8259, application/json does not have a charset parameter