### PR TITLE
[Ui Enhancement] Fix positioning on currency symbol

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/views/CurrencyAmountInput.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/views/CurrencyAmountInput.java
@@ -308,9 +308,13 @@ public class CurrencyAmountInput extends LinearLayout implements CustomViewHelpe
 		public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, @NonNull Paint paint){
 			this.paint.setColor(paint.getColor());
 			this.paint.setAlpha(77);
-			if(!symbolBeforeAmount)
+			if(!symbolBeforeAmount){
 				x+=dp(2);
-			canvas.drawText(currentCurrency.symbol, x, top+dp(1.5f)-this.paint.ascent(), this.paint);
+			}
+			int verticalCenter=(top+bottom)/2;
+			float textHeight=this.paint.descent()-this.paint.ascent();
+			float yPosition=verticalCenter+(textHeight/2)-this.paint.descent();
+			canvas.drawText(currentCurrency.symbol, x, yPosition, this.paint);
 		}
 	}
 


### PR DESCRIPTION
This pull request adjusts the position of the currency symbol in the donation section, centering it for better alignment.

I'm not sure if the original placement was intentional, but it appeared slightly off to me. I've updated the draw function to ensure the symbol is properly centered within its area.

Tested on two Android versions: 29 and 34.

### Screenshots 
#### Before 

<img width="439" alt="Screenshot 2024-08-22 at 12 27 23 PM" src="https://github.com/user-attachments/assets/3dace593-159e-4254-af83-ae0b3012274e">
<img width="437" alt="Screenshot 2024-08-22 at 12 27 42 PM" src="https://github.com/user-attachments/assets/4d505d7c-0ab9-46b5-8397-ec5aded94e39">

#### After 
<img width="439" alt="Screenshot 2024-08-22 at 12 22 46 PM" src="https://github.com/user-attachments/assets/d2f9242c-52af-485a-8808-1a79126d0d55">
<img width="440" alt="Screenshot 2024-08-22 at 12 23 38 PM" src="https://github.com/user-attachments/assets/1f7b8e04-b675-4a77-b33c-4f95684df34a">

