### PR TITLE
Detect hashtag links just like the web UI does

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -145,15 +145,14 @@ public class HtmlParser{
 							Object linkObject=null;
 							String href=el.attr("href");
 							LinkSpan.Type linkType;
-							if(el.hasClass("hashtag")){
-								String text=el.text();
-								if(text.startsWith("#")){
-									linkType=LinkSpan.Type.HASHTAG;
-									href=text.substring(1);
-									linkObject=tagsByTag.get(text.substring(1).toLowerCase());
-								}else{
-									linkType=LinkSpan.Type.URL;
-								}
+							String text=el.text();
+							boolean startsWithHash=text.startsWith("#");
+							Node previous=el.previousSibling();
+							if(startsWithHash || previous != null && previous.text().startsWith("#")){
+								String tag=startsWithHash ? text.substring(1) : text;
+								linkType=LinkSpan.Type.HASHTAG;
+								href=tag;
+								linkObject=tagsByTag.get(tag.toLowerCase());
 							}else if(el.hasClass("mention")){
 								String id=idsByUrl.get(href);
 								if(id!=null){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -148,7 +148,7 @@ public class HtmlParser{
 							String text=el.text();
 							boolean startsWithHash=text.startsWith("#");
 							Node previous=el.previousSibling();
-							if(startsWithHash || previous != null && previous.text().startsWith("#")){
+							if(startsWithHash || previous != null && previous.text().endsWith("#")){
 								String tag=startsWithHash ? text.substring(1) : text;
 								linkType=LinkSpan.Type.HASHTAG;
 								href=tag;


### PR DESCRIPTION
Fixes #959.

See <https://github.com/mastodon/mastodon/blob/67a8d4638c6e6a3ef178258504a6535746608c42/app/javascript/hooks/useLinks.ts#L13-L15> for the web logic.

Please note that I did not check whether this issue also exists in the iOS app, as I didn't find the matching part of the code there.