### PR TITLE
Follow requests acceptance/rejection

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/AcceptFollowRequest.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/AcceptFollowRequest.java
@@ -1,0 +1,11 @@
+package org.joinmastodon.android.api.requests.accounts;
+
+import org.joinmastodon.android.api.MastodonAPIRequest;
+import org.joinmastodon.android.model.Relationship;
+
+public class AcceptFollowRequest extends MastodonAPIRequest<Relationship> {
+	public AcceptFollowRequest(String accountID) {
+		super(HttpMethod.POST, "/follow_requests/" + accountID + "/authorize", Relationship.class);
+		setRequestBody(new Object());
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RejectFollowRequest.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RejectFollowRequest.java
@@ -1,0 +1,11 @@
+package org.joinmastodon.android.api.requests.accounts;
+
+import org.joinmastodon.android.api.MastodonAPIRequest;
+import org.joinmastodon.android.model.Relationship;
+
+public class RejectFollowRequest extends MastodonAPIRequest<Relationship> {
+	public RejectFollowRequest(String accountID) {
+		super(HttpMethod.POST, "/follow_requests/" + accountID + "/reject", Relationship.class);
+		setRequestBody(new Object());
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/NotificationHeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/NotificationHeaderStatusDisplayItem.java
@@ -9,16 +9,20 @@ import android.text.TextUtils;
 import android.text.style.TypefaceSpan;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.requests.accounts.AcceptFollowRequest;
+import org.joinmastodon.android.api.requests.accounts.RejectFollowRequest;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.fragments.ProfileFragment;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.NotificationType;
+import org.joinmastodon.android.model.Relationship;
 import org.joinmastodon.android.model.viewmodel.NotificationViewModel;
 import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.text.HtmlParser;
@@ -33,6 +37,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.Nav;
+import me.grishka.appkit.api.ErrorResponse;
+import me.grishka.appkit.api.SimpleCallback;
 import me.grishka.appkit.imageloader.ImageLoaderViewHolder;
 import me.grishka.appkit.imageloader.requests.ImageLoaderRequest;
 import me.grishka.appkit.imageloader.requests.UrlImageLoaderRequest;
@@ -181,9 +187,69 @@ public class NotificationHeaderStatusDisplayItem extends StatusDisplayItem{
 				ImageLoaderViewHolder.super.clearImage(index);
 		}
 
+		private void acceptFollowRequest(View v){
+			var parentFragment = this.getItem().parentFragment;
+			var acceptButton = findViewById(R.id.notification_approve);
+
+			acceptButton.setEnabled(false);
+
+			new AcceptFollowRequest(this.getItem().notification.accounts.get(0).id)
+					.setCallback(new SimpleCallback<>(this.getItem().parentFragment){
+						@Override
+						public void onSuccess(Relationship result){
+							parentFragment.reload();
+						}
+						@Override
+						public void onError(ErrorResponse error){
+							super.onError(error);
+							acceptButton.setEnabled(true);
+						}
+					}).exec(parentFragment.getAccountID());
+		}
+
+		private void rejectFollowRequest(View v){
+			var parentFragment = this.getItem().parentFragment;
+			var rejectButton = findViewById(R.id.notification_decline);
+
+			rejectButton.setEnabled(false);
+
+			new RejectFollowRequest(this.getItem().notification.accounts.get(0).id)
+					.setCallback(new SimpleCallback<>(this.getItem().parentFragment){
+						@Override
+						public void onSuccess(Relationship result){
+							parentFragment.reload();
+						}
+						@Override
+						public void onError(ErrorResponse error) {
+							super.onError(error);
+							rejectButton.setEnabled(true);
+						}
+					}).exec(parentFragment.getAccountID());
+		}
+
 		@Override
 		public void onBind(NotificationHeaderStatusDisplayItem item){
 			text.setText(item.text);
+
+			var actionsView = findViewById(R.id.notification_actions);
+			Button approveButton = findViewById(R.id.notification_approve);
+			Button declineButton = findViewById(R.id.notification_decline);
+
+			if (item.notification.notification.type == NotificationType.FOLLOW_REQUEST) {
+				actionsView.setVisibility(View.VISIBLE);
+				approveButton.setOnClickListener(this::acceptFollowRequest);
+				approveButton.setEnabled(true);
+				approveButton.setText(R.string.confirm);
+
+				declineButton.setOnClickListener(this::rejectFollowRequest);
+				declineButton.setEnabled(true);
+				declineButton.setText(R.string.delete);
+			} else {
+				actionsView.setVisibility(View.GONE);
+				approveButton.setOnClickListener(null);
+				declineButton.setOnClickListener(null);
+			}
+
 			if(item.notification.notification.type==NotificationType.POLL || item.notification.notification.type==NotificationType.UPDATE){
 				avatarsContainer.setVisibility(View.GONE);
 			}else{

--- a/mastodon/src/main/res/color/button_text_m3_filled_secondary.xml
+++ b/mastodon/src/main/res/color/button_text_m3_filled_secondary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:color="?colorM3OnSecondary" android:state_enabled="true"/>
+	<item android:color="?colorM3OnSurface" android:alpha="0.38"/>
+</selector>

--- a/mastodon/src/main/res/drawable/bg_button_m3_filled_secondary.xml
+++ b/mastodon/src/main/res/drawable/bg_button_m3_filled_secondary.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:state_enabled="true">
+		<ripple android:color="@color/m3_pressed_overlay">
+			<item>
+				<shape>
+					<solid android:color="?colorM3Secondary"/>
+					<corners android:radius="100dp"/>
+				</shape>
+			</item>
+		</ripple>
+	</item>
+	<item>
+		<shape>
+			<solid android:color="?colorM3DisabledBackground"/>
+			<corners android:radius="100dp"/>
+		</shape>
+	</item>
+</selector>

--- a/mastodon/src/main/res/layout/display_item_notification_header.xml
+++ b/mastodon/src/main/res/layout/display_item_notification_header.xml
@@ -76,4 +76,43 @@
 		android:textAlignment="viewStart"
 		tools:text="Notification text"/>
 
+	<LinearLayout
+		android:id="@+id/notification_actions"
+		android:layout_alignStart="@id/text"
+		android:layout_alignEnd="@id/text"
+		android:layout_alignParentEnd="true"
+		android:layout_below="@id/text"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:orientation="horizontal">
+		<Button
+			android:id="@+id/notification_approve"
+			android:layout_width="0dp"
+			android:layout_weight="1"
+			android:layout_height="32dp"
+			android:layout_marginTop="4dp"
+			android:layout_marginBottom="8dp"
+			android:minWidth="0dp"
+			android:drawableStart="@drawable/ic_check_20px"
+			android:drawableTint="@color/button_text_m3_filled"
+			android:textAlignment="center"
+			tools:text="Yes"
+			style="@style/Widget.Mastodon.M3.Button.Filled"
+			/>
+		<Button
+			android:id="@+id/notification_decline"
+			android:layout_width="0dp"
+			android:layout_weight="1"
+			android:layout_height="32dp"
+			android:layout_marginTop="4dp"
+			android:layout_marginBottom="8dp"
+			android:layout_marginStart="8dp"
+			android:minWidth="0dp"
+			android:drawableStart="@drawable/ic_block_20px"
+			android:drawableTint="@color/button_text_m3_filled_secondary"
+			android:textAlignment="center"
+			tools:text="No"
+			style="@style/Widget.Mastodon.M3.Button.Filled.Secondary"
+			/>
+	</LinearLayout>
 </RelativeLayout>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
 	<string name="do_block">Block</string>
 	<string name="button_blocked">Blocked</string>
 	<string name="action_vote">Vote</string>
+	<string name="confirm">Confirm</string>
 	<string name="delete">Delete</string>
 	<string name="confirm_delete_title">Delete post</string>
 	<string name="confirm_delete">Are you sure you want to delete this post?</string>

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -542,6 +542,13 @@
 		<item name="android:paddingRight">24dp</item>
 	</style>
 
+	<style name="Widget.Mastodon.M3.Button.Filled.Secondary">
+		<item name="android:background">@drawable/bg_button_m3_filled_secondary</item>
+		<item name="android:textColor">@color/button_text_m3_filled_secondary</item>
+		<item name="android:paddingLeft">24dp</item>
+		<item name="android:paddingRight">24dp</item>
+	</style>
+
 	<style name="Widget.Mastodon.M3.Button.Text">
 		<item name="android:background">@drawable/bg_button_m3_text</item>
 		<item name="android:textColor">@color/button_text_m3_text</item>


### PR DESCRIPTION
Closes #809, closes #763, closes #265, closes #105

When I was using Mastodon Android, ability to accept/decline follow requests was only one blocking feature when I had to open web client to do so.

I've added accept/reject buttons to follow request notification to reflect the same UI existing in Mastodon iOS nowadays:



 <table>
  <tr>
    <td>
<img src="https://github.com/user-attachments/assets/243b49d3-e53a-4d1f-88ee-05345ca9c0e2" width="200px" />
</td>
    <td>
<img src="https://github.com/user-attachments/assets/862ebba0-541f-4a76-94dc-9a884f947cbe" width="200px" />
</td>
  </tr>
<tr>
    <td>
<p>UI, implemented in this PR</p>
</td>
    <td>
<p>Mastodon iOS UI</p>
</td>
</tr>
</table> 