### PR TITLE
Include first 100 characters of status text when sharing to share sheet.

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -1011,30 +1011,32 @@ public class UiUtils{
 		Intent intent=new Intent(Intent.ACTION_SEND);
 		intent.setType("text/plain");
 		Account account;
-		String url;
+		String text;
 		String previewTitle;
 
 		if(obj instanceof Account acc){
 			account=acc;
-			url=acc.url;
+			text=acc.url;
 			previewTitle=context.getString(R.string.share_sheet_preview_profile, account.displayName);
 		}else if(obj instanceof Status st){
 			account=st.account;
-			url=st.url;
 			String postText=st.getStrippedText();
 			if(TextUtils.isEmpty(postText)){
 				previewTitle=context.getString(R.string.share_sheet_preview_profile, account.displayName);
+				text=st.url;
 			}else{
 				if(postText.length()>100)
 					postText=postText.substring(0, 100)+"...";
 				previewTitle=context.getString(R.string.share_sheet_preview_post, account.displayName, postText);
+				text=context.getString(R.string.share_sheet_post, account.displayName, postText, st.url);
 			}
 		}else{
 			throw new IllegalArgumentException("Unsupported share object type");
 		}
 
-		intent.putExtra(Intent.EXTRA_TEXT, url);
+		intent.putExtra(Intent.EXTRA_TEXT, text);
 		intent.putExtra(Intent.EXTRA_TITLE, previewTitle);
+		intent.putExtra(Intent.EXTRA_SUBJECT, previewTitle);
 		ImageCache cache=ImageCache.getInstance(context);
 		try{
 			File ava=cache.getFile(new UrlImageLoaderRequest(account.avatarStatic));

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -700,6 +700,7 @@
 	<string name="view_file">View</string>
 	<string name="share_sheet_preview_profile">%s on Mastodon</string>
 	<string name="share_sheet_preview_post">%1$s on Mastodon: “%2$s”</string>
+    <string name="share_sheet_post">%1$s on Mastodon: “%2$s\n\n%3$s”</string>
 	<string name="copy_profile_link">Copy link to profile</string>
 	<string name="in_app_browser">In-app browser</string>
 	<string name="system_browser">System browser</string>


### PR DESCRIPTION
Currently, sharing a post just shares the URL, which doesn't give much context when I email it to myself for later reference and want to remember what it was about. This PR adds the beginning of the status message as well to add that context.