### PR TITLE
Avoid invalid cast of `parentFragment` in `StatusDisplayItem`

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -80,8 +80,8 @@ public abstract class StatusDisplayItem{
 			case AUDIO -> new AudioStatusDisplayItem.Holder(activity, parent);
 			case POLL_OPTION -> new PollOptionStatusDisplayItem.Holder(activity, parent);
 			case POLL_FOOTER -> new PollFooterStatusDisplayItem.Holder(activity, parent);
-			case CARD_LARGE -> new LinkCardStatusDisplayItem.Holder(activity, parent, true, ((BaseStatusListFragment<?>)parentFragment).getAccountID());
-			case CARD_COMPACT -> new LinkCardStatusDisplayItem.Holder(activity, parent, false, ((BaseStatusListFragment<?>)parentFragment).getAccountID());
+			case CARD_LARGE -> new LinkCardStatusDisplayItem.Holder(activity, parent, true, parentFragment.getArguments().getString("account"));
+			case CARD_COMPACT -> new LinkCardStatusDisplayItem.Holder(activity, parent, false, parentFragment.getArguments().getString("account"));
 			case FOOTER -> new FooterStatusDisplayItem.Holder(activity, parent);
 			case ACCOUNT -> new AccountStatusDisplayItem.Holder(new AccountViewHolder(parentFragment, parent, null));
 			case HASHTAG -> new HashtagStatusDisplayItem.Holder(activity, parent);


### PR DESCRIPTION
`parentFragment` can be a `ComposeFragment` when quoting a post and cannot be casted to `BaseStatusListFragment` (see https://github.com/mastodon/mastodon-android/issues/1031#issuecomment-3354326124 for details).

The account id returned by `BaseStatusListFragment.getAccountID()` is obtained using [`getArguments().getString("account")`][accID] and the same also works for `ComposeFragment`.

[accID]: https://github.com/mastodon/mastodon-android/blob/8d19e4928661af2eb29d88712eaee74e1921a8cf/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java#L118

Fixes #1031