### PR TITLE
Add a copy button for images

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
@@ -9,6 +9,8 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
@@ -135,7 +137,7 @@ public class PhotoViewer implements ZoomPanView.Listener{
 	private ImageButton videoPlayPauseButton;
 	private View videoControls;
 	private TextView altText;
-	private ImageButton backButton, downloadButton;
+	private ImageButton backButton, copyButton, downloadButton;
 	private View bottomBar;
 	private View postActions;
 	private View replyBtn, boostBtn, favoriteBtn, shareBtn, bookmarkBtn;
@@ -274,6 +276,12 @@ public class PhotoViewer implements ZoomPanView.Listener{
 		toolbarWrap=uiOverlay.findViewById(R.id.toolbar_wrap);
 		backButton=uiOverlay.findViewById(R.id.btn_back);
 		backButton.setOnClickListener(v->onStartSwipeToDismissTransition(0));
+		copyButton=uiOverlay.findViewById(R.id.btn_copy);
+		if(attachments.get(index).type!=Attachment.Type.IMAGE){
+			copyButton.setVisibility(View.GONE);
+		} else{
+			copyButton.setOnClickListener(v->copyCurrentFile(v.getContext()));
+		}
 		downloadButton=uiOverlay.findViewById(R.id.btn_download);
 		downloadButton.setOnClickListener(v->saveCurrentFile());
 		bottomBar=uiOverlay.findViewById(R.id.bottom_bar);
@@ -414,6 +422,7 @@ public class PhotoViewer implements ZoomPanView.Listener{
 	}
 
 	public void removeMenu(){
+		copyButton.setVisibility(View.GONE);
 		downloadButton.setVisibility(View.GONE);
 	}
 
@@ -565,6 +574,7 @@ public class PhotoViewer implements ZoomPanView.Listener{
 	private void onPageChanged(int index){
 		currentIndex=index;
 		Attachment att=attachments.get(index);
+		V.setVisibilityAnimated(copyButton, att.type==Attachment.Type.IMAGE ? View.VISIBLE : View.GONE);
 		V.setVisibilityAnimated(videoControls, att.type==Attachment.Type.VIDEO ? View.VISIBLE : View.GONE);
 		if(att.type==Attachment.Type.VIDEO){
 			videoSeekBar.setSecondaryProgress(0);
@@ -703,6 +713,20 @@ public class PhotoViewer implements ZoomPanView.Listener{
 
 	public void onPause(){
 		pauseVideo();
+	}
+
+	private void copyCurrentFile(Context context) {
+		Attachment att=attachments.get(pager.getCurrentItem());
+		if(att.type!=Attachment.Type.IMAGE) return;
+		ImageCache cache=ImageCache.getInstance(context);
+		try{
+			File file=cache.getFile(new UrlImageLoaderRequest(att.url));
+			if(file!=null && file.exists()){
+				ClipData clipData=ClipData.newRawUri(null, UiUtils.getFileProviderUri(context, file));
+				ClipboardManager clipboard=(ClipboardManager)context.getSystemService(Context.CLIPBOARD_SERVICE);
+				clipboard.setPrimaryClip(clipData);
+			}
+		}catch(IOException ignore){}
 	}
 
 	private void saveCurrentFile(){

--- a/mastodon/src/main/res/drawable/ic_copy_20px.xml
+++ b/mastodon/src/main/res/drawable/ic_copy_20px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M360,720q-29.7,0 -50.85,-21.15Q288,677.7 288,648v-480q0,-29.7 21.15,-50.85Q330.3,96 360,96h384q29.7,0 50.85,21.15Q816,138.3 816,168v480q0,29.7 -21.15,50.85Q773.7,720 744,720L360,720ZM360,648h384v-480L360,168v480ZM216,864q-29.7,0 -50.85,-21.15Q144,821.7 144,792v-552h72v552h456v72L216,864ZM360,648v-480,480Z"/>
+</vector>

--- a/mastodon/src/main/res/layout/photo_viewer_ui.xml
+++ b/mastodon/src/main/res/layout/photo_viewer_ui.xml
@@ -29,6 +29,17 @@
 				android:contentDescription="@string/back"/>
 
 			<ImageButton
+				android:id="@+id/btn_copy"
+				android:layout_width="48dp"
+				android:layout_height="48dp"
+				android:layout_gravity="center_vertical|end"
+				android:layout_marginEnd="56dp"
+				android:src="@drawable/ic_copy_20px"
+				android:tint="#fff"
+				android:background="@drawable/bg_photo_viewer_toolbar_button"
+				android:contentDescription="@string/copy"/>
+
+			<ImageButton
 				android:id="@+id/btn_download"
 				android:layout_width="48dp"
 				android:layout_height="48dp"


### PR DESCRIPTION
Some apps (such as Firefox) let you copy images, while others (such as Element and even this app) allow pasting images

So, let's add copying