### PR TITLE
Update contributing guidelines to point to main org policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Crowdin](https://badges.crowdin.net/mastodon-for-android/localized.svg)](https://crowdin.com/project/mastodon-for-android)
 
-This is the repository for the official Android app for Mastodon.
-
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
      alt="Get it on F-Droid"
      height="80">](https://f-droid.org/packages/org.joinmastodon.android/)
@@ -13,11 +11,17 @@ This is the repository for the official Android app for Mastodon.
 
 You can also get the APK from the [the Releases section](https://github.com/mastodon/mastodon-android/releases/latest).
 
+## Introduction
+
+This is the repository for the official Android app for Mastodon.
+
+Please note that this app is intended to be used with Mastodon servers. Our team does not have bandwidth to ensure compatibility with other server software, which means that unsolicited pull requests focused on that goal will most likely be closed.
+
 ## Contributing
 
 First, please read the Mastodon project [Contributing guide](https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md).
 
-In addition, note that user interface changes for our official apps are carried out through a design process that involves core team review - most changes of this kind will not be accepted as community contributions; if they are accepted, they will take time to go through this review.
+Note that user interface changes for our official apps are carried out through a design process that involves core team review - most changes of this kind will not be accepted as community contributions; if they are accepted, they will take time to go through this review.
 
 If you would like to help translate the app into your language, please go to [Crowdin](https://crowdin.com/project/mastodon-for-android). If your language is not listed in the Crowdin project, please create an issue and we will add it. Please do not create pull requests that modify `strings.xml` files for languages other than English.
 


### PR DESCRIPTION
Clean up README, point to top-level organisation Contribution guidelines (which incorporate other references like Code of Conduct and other policies). Also remove gGmbH leftover reference.