### PR TITLE
Enable more comprehensive R8 optimizations

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -23,7 +23,7 @@ android {
 		release {
 			minifyEnabled true
 			shrinkResources true
-			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 		}
 		debug{
 			debuggable true


### PR DESCRIPTION
Previously used proguard rules disabled a number of optimizations in R8.

See https://android-developers.googleblog.com/2026/03/monzo-boosts-performance-metrics-by-up-to-35-percent.html#:~:text=Enabling%20optimizations%20with%20a%20single%20change