### PR TITLE
Use the server's https origin as baseUrl when rendering the extended description

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
@@ -195,8 +195,9 @@ public class SettingsServerAboutFragment extends LoaderFragment{
 							}
 
 							final String html=template;
+							final String baseUrl="https://"+AccountSessionManager.get(accountID).domain+"/";
 							activity.runOnUiThread(()->{
-								webView.loadDataWithBaseURL(null, html, "text/html; charset=utf-8", null, null);
+								webView.loadDataWithBaseURL(baseUrl, html, "text/html; charset=utf-8", null, null);
 							});
 						});
 					}


### PR DESCRIPTION
Closes #1093.

`SettingsServerAboutFragment` renders the server's `extended_description` HTML in a WebView with `setJavaScriptEnabled(true)` and passes `null` as the baseUrl to `loadDataWithBaseURL`:

```java
webView.loadDataWithBaseURL(null, html, "text/html; charset=utf-8", null, null);
```

The `extended_description` content comes from the server's instance API, so the HTML is text the server admin writes. With `null` as the baseUrl the rendered page has an opaque `about:blank` origin, and any link or `window.open` call inside the description reaches the `shouldOverrideUrlLoading` handler, which routes non-http schemes (`intent:`, `market:`, `mailto:`, `sms:`, etc.) to `Intent.ACTION_VIEW` without an explicit allow-list.

### Change

Pass the account's instance domain as an https baseUrl:

```java
final String baseUrl="https://"+AccountSessionManager.get(accountID).domain+"/";
webView.loadDataWithBaseURL(baseUrl, html, "text/html; charset=utf-8", null, null);
```

This gives the rendered description a deterministic origin tied to the server that produced the HTML, which is the same identity the page would have if a user opened `/about/more` on the server directly. The description renders the same way it did before. No other WebView setting is touched.

Assisted-by: Claude (Anthropic)