### PR TITLE
Fix wrong string in en_rGB

### DIFF
--- a/mastodon/src/main/res/values-en-rGB/strings.xml
+++ b/mastodon/src/main/res/values-en-rGB/strings.xml
@@ -898,7 +898,7 @@ The more people you follow, the more active and interesting it will be.</string>
 	<string name="feature_user">Feature on my profile</string>
 	<string name="add_user_personal_note">Add a personal note</string>
 	<string name="mute_account">Mute account</string>
-	<string name="block_account">Mute account</string>
+	<string name="block_account">Block account</string>
 	<string name="remove_follower">Remove follower</string>
 	<string name="report_account">Report account</string>
 	<string name="unblock_account">Unblock account</string>


### PR DESCRIPTION
Fix string to correctly state "Block account" instead of "Mute account".

Fixes #1122